### PR TITLE
Allow customization of RestAdapter.

### DIFF
--- a/src/main/java/com/uwetrottmann/tmdb/Tmdb.java
+++ b/src/main/java/com/uwetrottmann/tmdb/Tmdb.java
@@ -28,34 +28,32 @@ import retrofit.RestAdapter;
 import retrofit.converter.GsonConverter;
 
 /**
- * Class to manage service creation with default settings.
+ * Helper class for easy usage of the TMDB v3 API using retrofit.
+ * <p/>
+ * Create an instance of this class, {@link #setApiKey(String)} and then call any of the service methods.
+ * <p/>
+ * The service methods take care of constructing the required {@link retrofit.RestAdapter} and creating the service. You
+ * can customize the {@link retrofit.RestAdapter} by overriding {@link #newRestAdapterBuilder()} and setting e.g.
+ * your own HTTP client instance or thread executor.
+ * <p/>
+ * Only one {@link retrofit.RestAdapter} instance is created upon the first and re-used for any consequent service
+ * method call.
  */
 public class Tmdb {
 
     /**
      * Tmdb API URL.
      */
-    private static final String API_URL = "https://api.themoviedb.org/3";
+    public static final String API_URL = "https://api.themoviedb.org/3";
 
     /**
      * API key query parameter name.
      */
-    private static final String PARAM_API_KEY = "api_key";
+    public static final String PARAM_API_KEY = "api_key";
 
-    /**
-     * API key.
-     */
-    private String mApiKey;
-
-    /**
-     * Whether to return more detailed log output.
-     */
-    private boolean mIsDebug;
-
-    /**
-     * Currently valid instance of RestAdapter.
-     */
-    private RestAdapter mRestAdapter;
+    private String apiKey;
+    private boolean isDebug;
+    private RestAdapter restAdapter;
 
     /**
      * Create a new manager instance.
@@ -64,73 +62,94 @@ public class Tmdb {
     }
 
     /**
-     * Set default API key.
+     * Set the TMDB API key.
+     * <p/>
+     * The next service method call will trigger a rebuild of the {@link retrofit.RestAdapter}. If you have cached any
+     * service instances, get a new one from its service method.
      *
-     * @param value API key value.
-     * @return Current instance for builder pattern.
+     * @param value Your TMDB API key.
      */
     public Tmdb setApiKey(String value) {
-        this.mApiKey = value;
-        mRestAdapter = null;
-        return this;
-    }
-
-    public Tmdb setIsDebug(boolean isDebug) {
-        mIsDebug = isDebug;
-        mRestAdapter = null;
+        this.apiKey = value;
+        restAdapter = null;
         return this;
     }
 
     /**
-     * If no instance exists yet, builds a new {@link RestAdapter} using the currently set API key
-     * and debug flag.
+     * Set the {@link retrofit.RestAdapter} log level.
+     *
+     * @param isDebug If true, the log level is set to {@link retrofit.RestAdapter.LogLevel#FULL}.
+     *                Otherwise {@link retrofit.RestAdapter.LogLevel#NONE}.
      */
-    private RestAdapter buildRestAdapter() {
-        if (mRestAdapter == null) {
-            RestAdapter.Builder builder = new RestAdapter.Builder()
-                    .setEndpoint(API_URL)
-                    .setConverter(new GsonConverter(TmdbHelper.getGsonBuilder().create()));
+    public Tmdb setIsDebug(boolean isDebug) {
+        this.isDebug = isDebug;
+        if (restAdapter != null) {
+            restAdapter.setLogLevel(isDebug ? RestAdapter.LogLevel.FULL : RestAdapter.LogLevel.NONE);
+        }
+        return this;
+    }
 
-            // if available, send mUsername and password in header
+    /**
+     * Create a new {@link retrofit.RestAdapter.Builder}. Override this to e.g. set your own client or executor.
+     *
+     * @return A {@link retrofit.RestAdapter.Builder} with no modifications.
+     */
+    protected RestAdapter.Builder newRestAdapterBuilder() {
+        return new RestAdapter.Builder();
+    }
+
+    /**
+     * Return the current {@link retrofit.RestAdapter} instance. If none exists (first call, API key changed),
+     * builds a new one.
+     * <p/>
+     * When building, sets the endpoint, a custom converter ({@link TmdbHelper#getGsonBuilder()})
+     * and a {@link retrofit.RequestInterceptor} which adds the API key as query param.
+     */
+    protected RestAdapter getRestAdapter() {
+        if (restAdapter == null) {
+            RestAdapter.Builder builder = newRestAdapterBuilder();
+
+            builder.setEndpoint(API_URL);
+            builder.setConverter(new GsonConverter(TmdbHelper.getGsonBuilder().create()));
             builder.setRequestInterceptor(new RequestInterceptor() {
                 @Override
                 public void intercept(RequestFacade requestFacade) {
-                    requestFacade.addQueryParam(PARAM_API_KEY, mApiKey);
+                    requestFacade.addQueryParam(PARAM_API_KEY, apiKey);
                 }
             });
 
-            if (mIsDebug) {
+            if (isDebug) {
                 builder.setLogLevel(RestAdapter.LogLevel.FULL);
             }
 
-            mRestAdapter = builder.build();
+            restAdapter = builder.build();
         }
 
-        return mRestAdapter;
+        return restAdapter;
     }
 
     public ConfigurationService configurationService() {
-        return buildRestAdapter().create(ConfigurationService.class);
+        return getRestAdapter().create(ConfigurationService.class);
     }
 
     public FindService findService() {
-        return buildRestAdapter().create(FindService.class);
+        return getRestAdapter().create(FindService.class);
     }
 
     public MoviesService moviesService() {
-        return buildRestAdapter().create(MoviesService.class);
+        return getRestAdapter().create(MoviesService.class);
     }
 
     public PersonService personService() {
-        return buildRestAdapter().create(PersonService.class);
+        return getRestAdapter().create(PersonService.class);
     }
 
     public SearchService searchService() {
-        return buildRestAdapter().create(SearchService.class);
+        return getRestAdapter().create(SearchService.class);
     }
 
     public TvService tvService() {
-        return buildRestAdapter().create(TvService.class);
+        return getRestAdapter().create(TvService.class);
     }
 
 }


### PR DESCRIPTION
- Pre-build a RestAdapter by simply overriding `newRestAdapterBuilder()`.
- Set the log level on an existing RestAdapter instead of rebuilding it.
