### PR TITLE
Add async variants of search and TV service methods.

### DIFF
--- a/src/main/java/com/uwetrottmann/tmdb/services/SearchService.java
+++ b/src/main/java/com/uwetrottmann/tmdb/services/SearchService.java
@@ -19,6 +19,7 @@ package com.uwetrottmann.tmdb.services;
 
 import com.uwetrottmann.tmdb.entities.MovieResultsPage;
 import com.uwetrottmann.tmdb.entities.TvResultsPage;
+import retrofit.Callback;
 import retrofit.http.GET;
 import retrofit.http.Query;
 
@@ -32,6 +33,15 @@ public interface SearchService {
     @GET("/search/movie")
     MovieResultsPage movie(
             @Query("query") String query
+    );
+
+    /**
+     * Async variant of {@link #movie(String)}.
+     */
+    @GET("/search/movie")
+    void movie(
+            @Query("query") String query,
+            Callback<MovieResultsPage> callback
     );
 
     /**
@@ -60,6 +70,21 @@ public interface SearchService {
     );
 
     /**
+     * Async variant of {@link #movie(String, Integer, String, Boolean, Integer, Integer, String)}.
+     */
+    @GET("/search/movie")
+    void movie(
+            @Query("query") String query,
+            @Query("page") Integer page,
+            @Query("language") String language,
+            @Query("include_adult") Boolean includeAdult,
+            @Query("year") Integer year,
+            @Query("primary_release_year") Integer primaryReleaseYear,
+            @Query("search_type") String searchType,
+            Callback<MovieResultsPage> callback
+    );
+
+    /**
      * Search for TV shows by title.
      *
      * @param query CGI escaped string
@@ -79,4 +104,17 @@ public interface SearchService {
             @Query("search_type") String searchType
     );
 
+
+    /**
+     * Async variant of {@link #tv(String, Integer, String, Integer, String)}.
+     */
+    @GET("/search/tv")
+    void tv(
+            @Query("query") String query,
+            @Query("page") Integer page,
+            @Query("language") String language,
+            @Query("first_air_date_year") Integer firstAirDateYear,
+            @Query("search_type") String searchType,
+            Callback<TvResultsPage> callback
+    );
 }

--- a/src/main/java/com/uwetrottmann/tmdb/services/TvService.java
+++ b/src/main/java/com/uwetrottmann/tmdb/services/TvService.java
@@ -2,6 +2,7 @@ package com.uwetrottmann.tmdb.services;
 
 import com.uwetrottmann.tmdb.entities.Credits;
 import com.uwetrottmann.tmdb.entities.ExternalIds;
+import retrofit.Callback;
 import retrofit.http.GET;
 import retrofit.http.Path;
 import retrofit.http.Query;
@@ -22,6 +23,16 @@ public interface TvService {
     );
 
     /**
+     * Async variant of {@link #credits(int, String)}.
+     */
+    @GET("/tv/{id}/credits")
+    void credits(
+            @Path("id") int tmdbId,
+            @Query("language") String language,
+            Callback<Credits> callback
+    );
+
+    /**
      * Get the external ids that we have stored for a TV series.
      *
      * @param tmdbId A themoviedb id.
@@ -31,6 +42,16 @@ public interface TvService {
     ExternalIds externalIds(
             @Path("id") int tmdbId,
             @Query("language") String language
+    );
+
+    /**
+     * Async variant of {@link #externalIds(int, String)}.
+     */
+    @GET("/tv/{id}/external_ids")
+    void externalIds(
+            @Path("id") int tmdbId,
+            @Query("language") String language,
+            Callback<ExternalIds> callback
     );
 
 }

--- a/src/test/java/com/uwetrottmann/tmdb/TestData.java
+++ b/src/test/java/com/uwetrottmann/tmdb/TestData.java
@@ -18,7 +18,9 @@ package com.uwetrottmann.tmdb;
 
 public interface TestData {
 
-    public int TVSHOW_ID = 1396;
-    public int TVSHOW_TVDB_ID = 81189;
+    String MOVIE_TITLE = "Fight Club";
 
+    String TVSHOW_TITLE = "Breaking Bad";
+    int TVSHOW_ID = 1396;
+    int TVSHOW_TVDB_ID = 81189;
 }

--- a/src/test/java/com/uwetrottmann/tmdb/services/SearchServiceTest.java
+++ b/src/test/java/com/uwetrottmann/tmdb/services/SearchServiceTest.java
@@ -1,39 +1,123 @@
-
 package com.uwetrottmann.tmdb.services;
 
 import com.uwetrottmann.tmdb.BaseTestCase;
+import com.uwetrottmann.tmdb.TestData;
+import com.uwetrottmann.tmdb.entities.BaseResultsPage;
 import com.uwetrottmann.tmdb.entities.MovieResultsPage;
 import com.uwetrottmann.tmdb.entities.TvResultsPage;
+import retrofit.Callback;
+import retrofit.RetrofitError;
+import retrofit.client.Response;
 
 import java.text.ParseException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 
 public class SearchServiceTest extends BaseTestCase {
 
+    private CountDownLatch lock = new CountDownLatch(1);
+    private MovieResultsPage movieResults;
+    private TvResultsPage tvResults;
+
     public void test_movieSearch() throws ParseException {
-        MovieResultsPage movieResults = getManager().searchService().movie("Fight Club");
-        assertNotNull("Result was null.", movieResults);
-        assertNotNull("Returned movie list was null.", movieResults.results);
-        assertNotNull("Returned page number was null.", movieResults.page);
-        assertNotNull("Total pages number was null.", movieResults.total_pages);
-        assertNotNull("Total results number was null.", movieResults.total_results);
+        MovieResultsPage movieResults = getManager().searchService().movie(TestData.MOVIE_TITLE);
+        assertMovieResults(movieResults);
+    }
+
+    public void test_movieSearch_async() throws Exception {
+        getManager().searchService().movie(TestData.MOVIE_TITLE, new Callback<MovieResultsPage>() {
+            @Override
+            public void success(MovieResultsPage movieResultsPage, Response response) {
+                SearchServiceTest.this.movieResults = movieResultsPage;
+                lock.countDown();
+            }
+
+            @Override
+            public void failure(RetrofitError retrofitError) {
+
+            }
+        });
+
+        lockAwait();
+
+        assertMovieResults(movieResults);
     }
 
     public void test_movieSearchWithNullParams() throws ParseException {
-        MovieResultsPage movieResults = getManager().searchService().movie("Fight Club", null, null,
+        MovieResultsPage movieResults = getManager().searchService().movie(TestData.MOVIE_TITLE, null, null,
                 null, null, null, null);
-        assertNotNull("Result was null.", movieResults);
-        assertNotNull("Returned movie list was null.", movieResults.results);
-        assertNotNull("Returned page number was null.", movieResults.page);
-        assertNotNull("Total pages number was null.", movieResults.total_pages);
-        assertNotNull("Total results number was null.", movieResults.total_results);
+        assertMovieResults(movieResults);
     }
-    
-    public void test_tv() {
-        TvResultsPage results = getManager().searchService().tv("Breaking Bad", null, null, null, null);
+
+    public void test_movieSearchWithNullParams_async() throws Exception {
+        getManager().searchService().movie(TestData.MOVIE_TITLE, null, null, null, null, null, null,
+                new Callback<MovieResultsPage>() {
+                    @Override
+                    public void success(MovieResultsPage movieResultsPage, Response response) {
+                        SearchServiceTest.this.movieResults = movieResultsPage;
+                        lock.countDown();
+                    }
+
+                    @Override
+                    public void failure(RetrofitError retrofitError) {
+
+                    }
+                });
+
+        lockAwait();
+
+        assertMovieResults(movieResults);
+    }
+
+    private void assertMovieResults(MovieResultsPage results) {
         assertThat(results.results).isNotEmpty();
-        assertThat(results.results.get(0).name).isEqualTo("Breaking Bad");
+        assertResultsPage(results);
+    }
+
+    public void test_tv() {
+        TvResultsPage tvResults = getManager().searchService().tv(TestData.TVSHOW_TITLE, null, null, null, null);
+        assertTvResults(tvResults);
+    }
+
+    public void test_tv_async() throws Exception {
+        getManager().searchService().tv(TestData.TVSHOW_TITLE, null, null, null, null, new Callback<TvResultsPage>() {
+            @Override
+            public void success(TvResultsPage tvResultsPage, Response response) {
+                SearchServiceTest.this.tvResults = tvResultsPage;
+                lock.countDown();
+            }
+
+            @Override
+            public void failure(RetrofitError retrofitError) {
+
+            }
+        });
+
+        lockAwait();
+
+        assertTvResults(tvResults);
+    }
+
+    private void assertTvResults(TvResultsPage tvResults) {
+        assertThat(tvResults.results).isNotEmpty();
+        assertThat(tvResults.results.get(0).name).isEqualTo(TestData.TVSHOW_TITLE);
+        assertResultsPage(tvResults);
+    }
+
+    private void assertResultsPage(BaseResultsPage results) {
+        assertThat(results.page).isPositive();
+        assertThat(results.total_pages).isPositive();
+        assertThat(results.total_results).isPositive();
+    }
+
+    private void lockAwait() {
+        try {
+            lock.await(10000, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
 }

--- a/src/test/java/com/uwetrottmann/tmdb/services/TvServiceTest.java
+++ b/src/test/java/com/uwetrottmann/tmdb/services/TvServiceTest.java
@@ -4,13 +4,46 @@ import com.uwetrottmann.tmdb.BaseTestCase;
 import com.uwetrottmann.tmdb.TestData;
 import com.uwetrottmann.tmdb.entities.Credits;
 import com.uwetrottmann.tmdb.entities.ExternalIds;
+import retrofit.Callback;
+import retrofit.RetrofitError;
+import retrofit.client.Response;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 
 public class TvServiceTest extends BaseTestCase {
 
+    private CountDownLatch lock = new CountDownLatch(1);
+    private Credits credits;
+    private ExternalIds ids;
+
     public void test_credits() {
         Credits credits = getManager().tvService().credits(TestData.TVSHOW_ID, null);
+        assertCredits(credits);
+    }
+
+    public void test_credits_async() throws Exception {
+        getManager().tvService().credits(TestData.TVSHOW_ID, null, new Callback<Credits>() {
+            @Override
+            public void success(Credits credits, Response response) {
+                TvServiceTest.this.credits = credits;
+                lock.countDown();
+            }
+
+            @Override
+            public void failure(RetrofitError retrofitError) {
+
+            }
+        });
+
+        lockAwait();
+
+        assertCredits(credits);
+    }
+
+    private void assertCredits(Credits credits) {
         assertThat(credits.id).isEqualTo(TestData.TVSHOW_ID);
         assertThat(credits.cast).isNotEmpty();
 
@@ -30,8 +63,39 @@ public class TvServiceTest extends BaseTestCase {
 
     public void test_externalIds() {
         ExternalIds ids = getManager().tvService().externalIds(TestData.TVSHOW_ID, null);
+        assertExternalIds(ids);
+    }
+
+    public void test_externalIds_async() throws Exception {
+        getManager().tvService().externalIds(TestData.TVSHOW_ID, null, new Callback<ExternalIds>() {
+            @Override
+            public void success(ExternalIds externalIds, Response response) {
+                ids = externalIds;
+                lock.countDown();
+            }
+
+            @Override
+            public void failure(RetrofitError retrofitError) {
+
+            }
+        });
+
+        lockAwait();
+
+        assertExternalIds(ids);
+    }
+
+    private void assertExternalIds(ExternalIds ids) {
         assertThat(ids.id).isEqualTo(TestData.TVSHOW_ID);
         assertThat(ids.tvdb_id).isEqualTo(TestData.TVSHOW_TVDB_ID);
+    }
+
+    private void lockAwait () {
+        try {
+            lock.await(10000, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
 }


### PR DESCRIPTION
- Moved some test constants to `TestData` class.
- Share assertions between sync and async methods.

Original PR by @joselufo at https://github.com/UweTrottmann/tmdb-java/pull/12.
