### PR TITLE
Release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,27 @@ Change Log
 Supported API calls
 -------------------
 
- * Configuration service
- * Find service
- * Movie service (incomplete)
- * Person service (incomplete)
- * Search service (incomplete)
- * Tv service (incomplete)
+ * [Configuration](http://docs.themoviedb.apiary.io/#reference/configuration)
+ * [Discover](http://docs.themoviedb.apiary.io/#reference/discover)
+ * [Find](http://docs.themoviedb.apiary.io/#reference/find)
+ * [Movies](http://docs.themoviedb.apiary.io/#reference/movies) _incomplete_
+ * [People](http://docs.themoviedb.apiary.io/#reference/people) _incomplete_
+ * [Search](http://docs.themoviedb.apiary.io/#reference/search) _incomplete_
+ * [TV](http://docs.themoviedb.apiary.io/#reference/tv) _incomplete_
+ * [TV Seasons](http://docs.themoviedb.apiary.io/#reference/tv-seasons) _incomplete_
+ * [TV Episodes](http://docs.themoviedb.apiary.io/#reference/tv-episodes) _incomplete_
+
+0.8.0 *(2015-02-23)*
+--------------------
+ * Support more services (Discover, TV seasons and episodes) and methods, thanks to @migueljteixeira!
+ * Drop method variants (e.g. movie summary call with just a TMDb id). Use the full parameter variant and supply `null`
+   for non-required query parameters.
+ * Drop any async variants for methods. They only encourage bad programming (e.g. not using proper background threads).
+ * Renamed `PersonService` to `PeopleService` to be consistent with docs.
+ * Switch to JUnit 4 for testing.
+ * Update `retrofit` to 1.9.0, which allows to drop the `okhttp-urlconnection` dependency.
+ * Update `okhttp` suggested dependency to 2.2.0.
+ * Require Java 1.7.
 
 0.7.0 *(2014-08-12)*
 --------------------

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Usage
 Add the following dependency to your Gradle project:
 
 ```groovy
-compile 'com.uwetrottmann:tmdb-java:0.7.0'
+compile 'com.uwetrottmann:tmdb-java:0.8.0'
 ```
 
 or your Maven project:
@@ -21,7 +21,7 @@ or your Maven project:
 <dependency>
     <groupId>com.uwetrottmann</groupId>
     <artifactId>tmdb-java</artifactId>
-    <version>0.7.0</version>
+    <version>0.8.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <groupId>com.uwetrottmann</groupId>
     <artifactId>tmdb-java</artifactId>
     <packaging>jar</packaging>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.8.0</version>
 
     <name>tmdb-java</name>
     <description>tmdb-java is a Java library that provides access to the themoviedatabase API v3.</description>

--- a/src/main/java/com/uwetrottmann/tmdb/Tmdb.java
+++ b/src/main/java/com/uwetrottmann/tmdb/Tmdb.java
@@ -21,7 +21,7 @@ import com.uwetrottmann.tmdb.services.ConfigurationService;
 import com.uwetrottmann.tmdb.services.DiscoverService;
 import com.uwetrottmann.tmdb.services.FindService;
 import com.uwetrottmann.tmdb.services.MoviesService;
-import com.uwetrottmann.tmdb.services.PersonService;
+import com.uwetrottmann.tmdb.services.PeopleService;
 import com.uwetrottmann.tmdb.services.SearchService;
 import com.uwetrottmann.tmdb.services.TvEpisodesService;
 import com.uwetrottmann.tmdb.services.TvSeasonsService;
@@ -142,8 +142,8 @@ public class Tmdb {
         return getRestAdapter().create(MoviesService.class);
     }
 
-    public PersonService personService() {
-        return getRestAdapter().create(PersonService.class);
+    public PeopleService personService() {
+        return getRestAdapter().create(PeopleService.class);
     }
 
     public SearchService searchService() {

--- a/src/main/java/com/uwetrottmann/tmdb/services/DiscoverService.java
+++ b/src/main/java/com/uwetrottmann/tmdb/services/DiscoverService.java
@@ -16,69 +16,64 @@
 
 package com.uwetrottmann.tmdb.services;
 
-import java.util.Date;
-
 import com.uwetrottmann.tmdb.entities.AppendToDiscoverResponse;
-import com.uwetrottmann.tmdb.entities.FindResults;
 import com.uwetrottmann.tmdb.entities.MovieResultsPage;
 import com.uwetrottmann.tmdb.entities.TvResultsPage;
 import com.uwetrottmann.tmdb.enumerations.SortBy;
-
 import retrofit.http.GET;
 import retrofit.http.Query;
+
+import java.util.Date;
 
 public interface DiscoverService {
 
     /**
      * Discover movies by different types of data like average rating, number of votes and genres.
      *
-     * @param include_adult <em>Optional.</em> Toggle the inclusion of adult titles.
-     * Expected value is a boolean, true or false. Default is false.
-     * @param include_video <em>Optional.</em> Toggle the inclusion of items marked as a video.
-     * Expected value is a boolean, true or false. Default is true.
+     * @param includeAdult <em>Optional.</em> Toggle the inclusion of adult titles. Expected value is a boolean, true or
+     * false. Default is false.
+     * @param includeVideo <em>Optional.</em> Toggle the inclusion of items marked as a video. Expected value is a
+     * boolean, true or false. Default is true.
      * @param language <em>Optional.</em> ISO 639-1 code.
      * @param page <em>Optional.</em> Minimum 1, maximum 1000.
-     * @param primary_release_year <em>Optional.</em> Filter the results so that only the primary release date
-     * year has this value. Expected value is a year.
-     * @param primary_release_date.gte <em>Optional.</em> Filter by the primary release date and only include
-     * those which are greater than or equal to the specified value. Expected format is YYYY-MM-DD.
-     * @param primary_release_date.lte <em>Optional.</em> Filter by the primary release date and only include
-     * those which are less or equal to the specified value. Expected format is YYYY-MM-DD.
-     * @param release_date.gte <em>Optional.</em> Filter by all available release dates and only include those
-     * which are greater or equal to the specified value. Expected format is YYYY-MM-DD.
-     * @param release_date.lte <em>Optional.</em> Filter by all available release dates and only include those
-     * which are less or equal to the specified value. Expected format is YYYY-MM-DD.
-     * @param sort_by <em>Optional.</em> Available options are: popularity.asc, popularity.desc, release_date.asc,
+     * @param primaryReleaseYear <em>Optional.</em> Filter the results so that only the primary release date year has
+     * this value. Expected value is a year.
+     * @param primaryReleaseYearGte <em>Optional.</em> Filter by the primary release date and only include those which
+     * are greater than or equal to the specified value. Expected format is YYYY-MM-DD.
+     * @param primaryReleaseYearLte <em>Optional.</em> Filter by the primary release date and only include those which
+     * are less or equal to the specified value. Expected format is YYYY-MM-DD.
+     * @param releaseDateGte <em>Optional.</em> Filter by all available release dates and only include those which are
+     * greater or equal to the specified value. Expected format is YYYY-MM-DD.
+     * @param releaseDateLte <em>Optional.</em> Filter by all available release dates and only include those which are
+     * less or equal to the specified value. Expected format is YYYY-MM-DD.
+     * @param sortBy <em>Optional.</em> Available options are: popularity.asc, popularity.desc, release_date.asc,
      * release_date.desc, revenue.asc, revenue.desc, primary_release_date.asc, primary_release_date.desc,
-     * original_title.asc, original_title.desc, vote_average.asc, vote_average.desc,
-     * vote_count.asc, vote_count.desc
-     * @param vote_count.gte <em>Optional.</em> Filter movies by their vote count and only include movies that
-     * have a vote count that is equal to or lower than the specified value.
-     * @param vote_count.lte <em>Optional.</em> Filter movies by their vote count and only include movies that
-     * have a vote count that is equal to or lower than the specified value. Expected value is an integer.
-     * @param vote_average.gte <em>Optional.</em> Filter movies by their vote average and only include those that
-     * have an average rating that is equal to or higher than the specified value. Expected value is a float.
-     * @param vote_average.lte <em>Optional.</em> Filter movies by their vote average and only include those that
-     * have an average rating that is equal to or lower than the specified value. Expected value is a float.
-     * @param with_cast <em>Optional.</em> Only include movies that have this person id added as a cast member.
-     * Expected value is an integer (the id of a person).
-     * @param with_crew <em>Optional.</em> Only include movies that have this person id added as a crew member.
-     * Expected value is an integer (the id of a person).
-     * @param with_companies <em>Optional.</em> Filter movies to include a specific company. Expected value is
-     * an integer (the id of a company).
-     * @param with_genres <em>Optional.</em> Only include movies with the specified genres. Expected value is
-     * an integer (the id of a genre). Multiple values can be specified.
-     * @param with_keywords <em>Optional.</em> Only include movies with the specified genres. Expected value is
-     * an integer (the id of a genre). Multiple values can be specified.
-     * @param with_people <em>Optional.</em> Only include movies that have these person id's added as a cast or
-     * crew member. Expected value is an integer (the id or ids of a person).
-     * @param year <em>Optional.</em> Filter the results by all available release dates that have the specified
-     * value added as a year. Expected value is an integer (year).
-     * 
-     * @return
+     * original_title.asc, original_title.desc, vote_average.asc, vote_average.desc, vote_count.asc, vote_count.desc
+     * @param voteCountGte <em>Optional.</em> Filter movies by their vote count and only include movies that have a vote
+     * count that is equal to or lower than the specified value.
+     * @param voteCountLte <em>Optional.</em> Filter movies by their vote count and only include movies that have a vote
+     * count that is equal to or lower than the specified value. Expected value is an integer.
+     * @param voteAverageGte <em>Optional.</em> Filter movies by their vote average and only include those that have an
+     * average rating that is equal to or higher than the specified value. Expected value is a float.
+     * @param voteAverageLte <em>Optional.</em> Filter movies by their vote average and only include those that have an
+     * average rating that is equal to or lower than the specified value. Expected value is a float.
+     * @param withCast <em>Optional.</em> Only include movies that have this person id added as a cast member. Expected
+     * value is an integer (the id of a person).
+     * @param withCrew <em>Optional.</em> Only include movies that have this person id added as a crew member. Expected
+     * value is an integer (the id of a person).
+     * @param withCompanies <em>Optional.</em> Filter movies to include a specific company. Expected value is an integer
+     * (the id of a company).
+     * @param withGenres <em>Optional.</em> Only include movies with the specified genres. Expected value is an integer
+     * (the id of a genre). Multiple values can be specified.
+     * @param withKeywords <em>Optional.</em> Only include movies with the specified genres. Expected value is an
+     * integer (the id of a genre). Multiple values can be specified.
+     * @param withPeople <em>Optional.</em> Only include movies that have these person id's added as a cast or crew
+     * member. Expected value is an integer (the id or ids of a person).
+     * @param year <em>Optional.</em> Filter the results by all available release dates that have the specified value
+     * added as a year. Expected value is an integer (year).
      */
     @GET("/discover/movie")
-    FindResults discoverMovie(
+    MovieResultsPage discoverMovie(
             @Query("include_adult") boolean includeAdult,
             @Query("include_video") boolean includeVideo,
             @Query("language") String language,
@@ -101,127 +96,28 @@ public interface DiscoverService {
             @Query("with_people") AppendToDiscoverResponse withPeople,
             @Query("year") Integer year
     );
-    
+
     /**
-     * Discover movies by different types of data like average rating, number of votes and genres.
-     *
-     * @param include_adult <em>Optional.</em> Toggle the inclusion of adult titles.
-     * Expected value is a boolean, true or false. Default is false.
-     * @param include_video <em>Optional.</em> Toggle the inclusion of items marked as a video.
-     * Expected value is a boolean, true or false. Default is true.
-     * @param language <em>Optional.</em> ISO 639-1 code.
-     * @param page <em>Optional.</em> Minimum 1, maximum 1000.
-     * @param primary_release_year <em>Optional.</em> Filter the results so that only the primary release date
-     * year has this value. Expected value is a year.
-     * @param primary_release_date.gte <em>Optional.</em> Filter by the primary release date and only include
-     * those which are greater than or equal to the specified value. Expected format is YYYY-MM-DD.
-     * @param primary_release_date.lte <em>Optional.</em> Filter by the primary release date and only include
-     * those which are less or equal to the specified value. Expected format is YYYY-MM-DD.
-     * @param release_date.gte <em>Optional.</em> Filter by all available release dates and only include those
-     * which are greater or equal to the specified value. Expected format is YYYY-MM-DD.
-     * @param release_date.lte <em>Optional.</em> Filter by all available release dates and only include those
-     * which are less or equal to the specified value. Expected format is YYYY-MM-DD.
-     * @param sort_by <em>Optional.</em> Available options are: popularity.asc, popularity.desc, release_date.asc,
-     * release_date.desc, revenue.asc, revenue.desc, primary_release_date.asc, primary_release_date.desc,
-     * original_title.asc, original_title.desc, vote_average.asc, vote_average.desc,
-     * vote_count.asc, vote_count.desc
-     * @param with_cast <em>Optional.</em> Only include movies that have this person id added as a cast member.
-     * Expected value is an integer (the id of a person).
-     * @param with_crew <em>Optional.</em> Only include movies that have this person id added as a crew member.
-     * Expected value is an integer (the id of a person).
-     * @param with_companies <em>Optional.</em> Filter movies to include a specific company. Expected value is
-     * an integer (the id of a company).
-     * @param with_genres <em>Optional.</em> Only include movies with the specified genres. Expected value is
-     * an integer (the id of a genre). Multiple values can be specified.
-     * @param with_keywords <em>Optional.</em> Only include movies with the specified genres. Expected value is
-     * an integer (the id of a genre). Multiple values can be specified.
-     * @param with_people <em>Optional.</em> Only include movies that have these person id's added as a cast or
-     * crew member. Expected value is an integer (the id or ids of a person).
-     * @param year <em>Optional.</em> Filter the results by all available release dates that have the specified
-     * value added as a year. Expected value is an integer (year).
-     * 
-     * @return
-     */
-    @GET("/discover/movie")
-    MovieResultsPage discoverMovie(
-            @Query("include_adult") boolean includeAdult,
-            @Query("include_video") boolean includeVideo,
-            @Query("language") String language,
-            @Query("page") Integer page,
-            @Query("primary_release_year") String primaryReleaseYear,
-            @Query("primary_release_date.gte") Date primaryReleaseYearGte,
-            @Query("primary_release_date.lte") Date primaryReleaseYearLte,
-            @Query("release_date.gte") Date releaseDateGte,
-            @Query("release_date.lte") Date releaseDateLte,
-            @Query("sort_by") SortBy sortBy,
-            @Query("with_cast") AppendToDiscoverResponse withCast,
-            @Query("with_crew") AppendToDiscoverResponse withCrew,
-            @Query("with_companies") AppendToDiscoverResponse withCompanies,
-            @Query("with_genres") AppendToDiscoverResponse withGenres,
-            @Query("with_keywords") AppendToDiscoverResponse withKeywords,
-            @Query("with_people") AppendToDiscoverResponse withPeople,
-            @Query("year") Integer year
-    );
-    
-    /**
-     * Discover TV shows by different types of data like average rating, number of votes, genres,
-     * the network they aired on and air dates.
+     * Discover TV shows by different types of data like average rating, number of votes, genres, the network they aired
+     * on and air dates.
      *
      * @param page <em>Optional.</em> Minimum 1, maximum 1000.
      * @param language <em>Optional.</em> ISO 639-1 code.
-     * @param sort_by <em>Optional.</em> Available options are: popularity.asc, popularity.desc, release_date.asc,
+     * @param sortBy <em>Optional.</em> Available options are: popularity.asc, popularity.desc, release_date.asc,
      * release_date.desc, revenue.asc, revenue.desc, primary_release_date.asc, primary_release_date.desc,
-     * original_title.asc, original_title.desc, vote_average.asc, vote_average.desc,
-     * vote_count.asc, vote_count.desc
-     * @param first_air_date_year <em>Optional.</em> Filter the results release dates to matches that include
-     * this value. Expected value is a year.
-     * @param vote_count.gte <em>Optional.</em> Only include TV shows that are equal to, or have a vote count
-     * higher than this value. Expected value is an integer.
-     * @param vote_average.gte <em>Optional.</em> Only include TV shows that are equal to, or have a higher
-     * average rating than this value. Expected value is a float.
-     * @param with_genres <em>Optional.</em> Only include TV shows with the specified genres. Expected value
-     * is an integer (the id of a genre). Multiple values can be specified.
-     * @param with_networks <em>Optional.</em> Filter TV shows to include a specific network.
-     * Expected value is an integer (the id of a network).
-     * @param first_air_date.gte <em>Optional.</em> The minimum release to include. Expected format is YYYY-MM-DD.
-     * @param first_air_date.lte <em>Optional.</em> The maximum release to include. Expected format is YYYY-MM-DD.
-     * 
-     * @return
-     */
-    @GET("/discover/tv")
-    MovieResultsPage discoverTv(
-            @Query("page") Integer page,
-            @Query("language") String language,
-            @Query("sort_by") SortBy sortBy,
-            @Query("first_air_date_year") String firstAirDateYear,
-            @Query("vote_count.gte") Integer voteCountGte,
-            @Query("vote_average.gte") Float voteAverageGte,
-            @Query("with_genres") AppendToDiscoverResponse withGenres,
-            @Query("with_networks") AppendToDiscoverResponse withNetworks,
-            @Query("first_air_date.gte") Date firstAirDateGte,
-            @Query("first_air_date.lte") Date firstAirDateLte
-    );
-    
-    /**
-     * Discover TV shows by different types of data like average rating, number of votes, genres,
-     * the network they aired on and air dates.
-     *
-     * @param page <em>Optional.</em> Minimum 1, maximum 1000.
-     * @param language <em>Optional.</em> ISO 639-1 code.
-     * @param sort_by <em>Optional.</em> Available options are: popularity.asc, popularity.desc, release_date.asc,
-     * release_date.desc, revenue.asc, revenue.desc, primary_release_date.asc, primary_release_date.desc,
-     * original_title.asc, original_title.desc, vote_average.asc, vote_average.desc,
-     * vote_count.asc, vote_count.desc
-     * @param first_air_date_year <em>Optional.</em> Filter the results release dates to matches that include
-     * this value. Expected value is a year.
-     * @param with_genres <em>Optional.</em> Only include TV shows with the specified genres. Expected value
-     * is an integer (the id of a genre). Multiple values can be specified.
-     * @param with_networks <em>Optional.</em> Filter TV shows to include a specific network.
-     * Expected value is an integer (the id of a network).
-     * @param first_air_date.gte <em>Optional.</em> The minimum release to include. Expected format is YYYY-MM-DD.
-     * @param first_air_date.lte <em>Optional.</em> The maximum release to include. Expected format is YYYY-MM-DD.
-     * 
-     * @return
+     * original_title.asc, original_title.desc, vote_average.asc, vote_average.desc, vote_count.asc, vote_count.desc
+     * @param firstAirDateYear <em>Optional.</em> Filter the results release dates to matches that include this value.
+     * Expected value is a year.
+     * @param voteCountGte <em>Optional.</em> Only include TV shows that are equal to, or have a vote count higher than
+     * this value. Expected value is an integer.
+     * @param voteAverageGte <em>Optional.</em> Only include TV shows that are equal to, or have a higher average rating
+     * than this value. Expected value is a float.
+     * @param withGenres <em>Optional.</em> Only include TV shows with the specified genres. Expected value is an
+     * integer (the id of a genre). Multiple values can be specified.
+     * @param withNetworks <em>Optional.</em> Filter TV shows to include a specific network. Expected value is an
+     * integer (the id of a network).
+     * @param firstAirDateGte <em>Optional.</em> The minimum release to include. Expected format is YYYY-MM-DD.
+     * @param firstAirDateLte <em>Optional.</em> The maximum release to include. Expected format is YYYY-MM-DD.
      */
     @GET("/discover/tv")
     TvResultsPage discoverTv(
@@ -229,6 +125,8 @@ public interface DiscoverService {
             @Query("language") String language,
             @Query("sort_by") SortBy sortBy,
             @Query("first_air_date_year") String firstAirDateYear,
+            @Query("vote_count.gte") Integer voteCountGte,
+            @Query("vote_average.gte") Float voteAverageGte,
             @Query("with_genres") AppendToDiscoverResponse withGenres,
             @Query("with_networks") AppendToDiscoverResponse withNetworks,
             @Query("first_air_date.gte") Date firstAirDateGte,

--- a/src/main/java/com/uwetrottmann/tmdb/services/MoviesService.java
+++ b/src/main/java/com/uwetrottmann/tmdb/services/MoviesService.java
@@ -17,18 +17,17 @@
 
 package com.uwetrottmann.tmdb.services;
 
-import com.uwetrottmann.tmdb.entities.Images;
-import com.uwetrottmann.tmdb.entities.MovieAlternativeTitles;
 import com.uwetrottmann.tmdb.entities.AppendToResponse;
 import com.uwetrottmann.tmdb.entities.Credits;
-import com.uwetrottmann.tmdb.entities.MovieKeywords;
+import com.uwetrottmann.tmdb.entities.Images;
 import com.uwetrottmann.tmdb.entities.ListResultsPage;
 import com.uwetrottmann.tmdb.entities.Movie;
+import com.uwetrottmann.tmdb.entities.MovieAlternativeTitles;
+import com.uwetrottmann.tmdb.entities.MovieKeywords;
 import com.uwetrottmann.tmdb.entities.MovieResultsPage;
 import com.uwetrottmann.tmdb.entities.Releases;
 import com.uwetrottmann.tmdb.entities.ReviewResultsPage;
 import com.uwetrottmann.tmdb.entities.Videos;
-
 import retrofit.http.GET;
 import retrofit.http.Path;
 import retrofit.http.Query;
@@ -48,7 +47,7 @@ public interface MoviesService {
             @Query("language") String language,
             @Query("append_to_response") AppendToResponse appendToResponse
     );
-    
+
     /**
      * Get the alternative titles for a specific movie id.
      *
@@ -70,7 +69,7 @@ public interface MoviesService {
     Credits credits(
             @Path("id") int tmdbId
     );
-    
+
     /**
      * Get the images (posters and backdrops) for a specific movie id.
      *
@@ -82,7 +81,7 @@ public interface MoviesService {
             @Path("id") int tmdbId,
             @Query("language") String language
     );
-    
+
     /**
      * Get the plot keywords for a specific movie id.
      *
@@ -102,15 +101,17 @@ public interface MoviesService {
     Releases releases(
             @Path("id") int tmdbId
     );
-    
+
     /**
      * Get the videos (trailers, teasers, clips, etc...) for a specific movie id.
      *
      * @param tmdbId TMDb id.
+     * @param language <em>Optional.</em> ISO 639-1 code.
      */
     @GET("/movie/{id}/videos")
     Videos videos(
-            @Path("id") int tmdbId
+            @Path("id") int tmdbId,
+            @Query("language") String language
     );
 
     /**
@@ -126,11 +127,11 @@ public interface MoviesService {
             @Query("page") Integer page,
             @Query("language") String language
     );
-    
+
     /**
      * Get the reviews for a particular movie id.
-     * 
-     * @param tmdbId   TMDb id.
+     *
+     * @param tmdbId TMDb id.
      * @param page <em>Optional.</em> Minimum value is 1, expected value is an integer.
      * @param language <em>Optional.</em> ISO 639-1 code.
      */
@@ -140,12 +141,12 @@ public interface MoviesService {
             @Query("page") Integer page,
             @Query("language") String language
     );
-    
+
     /**
      * Get the lists that the movie belongs to.
-     * 
-     * @param tmdbId   TMDb id.
-     * @param page     <em>Optional.</em> Minimum value is 1, expected value is an integer.
+     *
+     * @param tmdbId TMDb id.
+     * @param page <em>Optional.</em> Minimum value is 1, expected value is an integer.
      * @param language <em>Optional.</em> ISO 639-1 code.
      */
     @GET("/movie/{id}/lists")
@@ -154,7 +155,7 @@ public interface MoviesService {
             @Query("page") Integer page,
             @Query("language") String language
     );
-    
+
     /**
      * Get the latest movie id.
      */

--- a/src/main/java/com/uwetrottmann/tmdb/services/PeopleService.java
+++ b/src/main/java/com/uwetrottmann/tmdb/services/PeopleService.java
@@ -22,12 +22,11 @@ import com.uwetrottmann.tmdb.entities.PersonCredits;
 import com.uwetrottmann.tmdb.entities.PersonIds;
 import com.uwetrottmann.tmdb.entities.PersonImages;
 import com.uwetrottmann.tmdb.entities.PersonResultsPage;
-
 import retrofit.http.GET;
 import retrofit.http.Path;
 import retrofit.http.Query;
 
-public interface PersonService {
+public interface PeopleService {
 
     /**
      * Get the general person information for a specific id.
@@ -74,38 +73,31 @@ public interface PersonService {
             @Path("id") int tmdbId,
             @Query("language") String language
     );
-    
+
     /**
      * Get the external ids for a specific person id.
-     *
-     * @param tmdbId TMDb id.
-     * @param language <em>Optional.</em> ISO 639-1 code.
      */
     @GET("/person/{id}/external_ids")
     PersonIds externalIds(
             @Path("id") int tmdbId
     );
-    
+
     /**
      * Get the images for a specific person id.
-     *
-     * @param tmdbId TMDb id.
-     * @param language <em>Optional.</em> ISO 639-1 code.
      */
     @GET("/person/{id}/images")
     PersonImages images(
             @Path("id") int tmdbId
     );
-    
+
     /**
      * Get the list of popular people on The Movie Database. This list refreshes every day.
-     *
-     * @param tmdbId TMDb id.
-     * @param language <em>Optional.</em> ISO 639-1 code.
      */
     @GET("/person/popular")
-    PersonResultsPage popular();
-    
+    PersonResultsPage popular(
+            @Query("page") Integer page
+    );
+
     /**
      * Get the latest person id.
      */

--- a/src/main/java/com/uwetrottmann/tmdb/services/TvSeasonsService.java
+++ b/src/main/java/com/uwetrottmann/tmdb/services/TvSeasonsService.java
@@ -42,7 +42,7 @@ public interface TvSeasonsService {
     );
     
     /**
-     * Get the cast & crew credits for a TV season by season number.
+     * Get the cast and crew credits for a TV season by season number.
      *
      * @param showId A themoviedb id.
      */

--- a/src/test/java/com/uwetrottmann/tmdb/TestData.java
+++ b/src/test/java/com/uwetrottmann/tmdb/TestData.java
@@ -18,11 +18,13 @@ package com.uwetrottmann.tmdb;
 
 public interface TestData {
 
+    int MOVIE_ID = 550;
     String MOVIE_TITLE = "Fight Club";
+    String MOVIE_IMDB = "tt0137523";
+
     String PERSON_NAME = "Brad Pitt";
     String TVSHOW_TITLE = "Breaking Bad";
     int TVSHOW_ID = 1396;
     int TVSHOW_TVDB_ID = 81189;
     int PERSON_ID = 287;
-    int MOVIE_ID = 550;
 }

--- a/src/test/java/com/uwetrottmann/tmdb/services/DiscoverServiceTest.java
+++ b/src/test/java/com/uwetrottmann/tmdb/services/DiscoverServiceTest.java
@@ -16,8 +16,6 @@
 
 package com.uwetrottmann.tmdb.services;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import com.uwetrottmann.tmdb.BaseTestCase;
 import com.uwetrottmann.tmdb.entities.AppendToDiscoverResponse;
 import com.uwetrottmann.tmdb.entities.BaseResultsPage;
@@ -26,34 +24,38 @@ import com.uwetrottmann.tmdb.entities.TvResultsPage;
 import com.uwetrottmann.tmdb.enumerations.SortBy;
 import org.junit.Test;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class DiscoverServiceTest extends BaseTestCase {
 
     private static final SimpleDateFormat JSON_STRING_DATE = new SimpleDateFormat("yyy-MM-dd");
-    
+
     @Test
     public void test_discover_movie() throws ParseException {
         MovieResultsPage results = getManager().discoverService().discoverMovie(false, true, null, 1,
                 null, JSON_STRING_DATE.parse("1990-01-01"), null, JSON_STRING_DATE.parse("1990-01-01"), null,
-                SortBy.POPULARITY_DESC, new AppendToDiscoverResponse(287), new AppendToDiscoverResponse(7467),
+                SortBy.POPULARITY_DESC, null, null, null, null, new AppendToDiscoverResponse(287),
+                new AppendToDiscoverResponse(7467),
                 null, new AppendToDiscoverResponse(10749), null, null, null);
-        
+
         assertResultsPage(results);
         assertThat(results.results).isNotEmpty();
     }
-    
+
     @Test
     public void test_discover_tv() throws ParseException {
         TvResultsPage results = getManager().discoverService().discoverTv(null, null,
-                SortBy.VOTE_AVERAGE_DESC, null, new AppendToDiscoverResponse(18, 10765),
+                SortBy.VOTE_AVERAGE_DESC, null, null, null, new AppendToDiscoverResponse(18, 10765),
                 new AppendToDiscoverResponse(49), JSON_STRING_DATE.parse("2010-01-01"),
                 JSON_STRING_DATE.parse("2014-01-01"));
-        
+
         assertResultsPage(results);
         assertThat(results.results).isNotEmpty();
     }
-    
+
     private void assertResultsPage(BaseResultsPage results) {
         assertThat(results.page).isPositive();
         assertThat(results.total_pages).isPositive();

--- a/src/test/java/com/uwetrottmann/tmdb/services/MoviesServiceTest.java
+++ b/src/test/java/com/uwetrottmann/tmdb/services/MoviesServiceTest.java
@@ -3,13 +3,13 @@ package com.uwetrottmann.tmdb.services;
 
 import com.uwetrottmann.tmdb.BaseTestCase;
 import com.uwetrottmann.tmdb.TestData;
-import com.uwetrottmann.tmdb.entities.Images;
-import com.uwetrottmann.tmdb.entities.MovieAlternativeTitles;
 import com.uwetrottmann.tmdb.entities.AppendToResponse;
 import com.uwetrottmann.tmdb.entities.Credits;
-import com.uwetrottmann.tmdb.entities.MovieKeywords;
+import com.uwetrottmann.tmdb.entities.Images;
 import com.uwetrottmann.tmdb.entities.ListResultsPage;
 import com.uwetrottmann.tmdb.entities.Movie;
+import com.uwetrottmann.tmdb.entities.MovieAlternativeTitles;
+import com.uwetrottmann.tmdb.entities.MovieKeywords;
 import com.uwetrottmann.tmdb.entities.MovieResultsPage;
 import com.uwetrottmann.tmdb.entities.Releases;
 import com.uwetrottmann.tmdb.entities.ReviewResultsPage;
@@ -18,70 +18,42 @@ import com.uwetrottmann.tmdb.enumerations.AppendToResponseItem;
 import org.junit.Test;
 
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 public class MoviesServiceTest extends BaseTestCase {
 
-    private static final SimpleDateFormat JSON_STRING_DATE = new SimpleDateFormat("yyy-MM-dd");
-
     @Test
     public void test_summary() throws ParseException {
         Movie movie = getManager().moviesService().summary(TestData.MOVIE_ID, null, null);
-        assertNotNull("Result was null.", movie);
-        assertNotNull("Movie Adult was null.", movie.adult);
-        assertThat(movie.adult).isFalse();
-        assertNotNull("Movie backdrop path was null.", movie.backdrop_path);
-        assertNotNull("Movie budget was null.", movie.budget);
-        assertEquals("Movie budget does not match.", 63000000, movie.budget.intValue());
-        assertNotNull("Movie TMDB ID was null.", movie.id);
-        assertEquals("Movie TMDB ID does not match.", TestData.MOVIE_ID, movie.id.intValue());
-        assertEquals("Movie IMDB ID does not match.", "tt0137523", movie.imdb_id);
-        assertEquals("Move orignal title does not match.", "Fight Club", movie.original_title);
-        assertNotNull("Movie overview was null.", movie.overview);
-        assertNotNull("Movie poster path was null.", movie.poster_path);
-        assertNotNull("Movie release date was null.", movie.release_date);
-        assertEquals("Movie release date does not match.", JSON_STRING_DATE.parse("1999-10-14"),
-                movie.release_date);
-        assertNotNull("Movie revenue was null.", movie.revenue);
-        assertEquals("Movie revenue does not match.", 100853753, movie.revenue.intValue());
-        assertNotNull("Movie runtime was null.", movie.runtime);
-        assertEquals("Movie runtime does not match.", 139, movie.runtime.intValue());
-        assertNotNull("Movie tagline was null.", movie.tagline);
-        assertEquals("Move title does not match.", "Fight Club", movie.title);
-        assertNotNull("Movie vote_average was null.", movie.vote_average);
-        assertNotNull("Movie vote_count was null.", movie.vote_count);
+        assertMovie(movie);
+        assertThat(movie.original_title).isEqualTo(TestData.MOVIE_TITLE);
     }
-    
+
     @Test
     public void test_summary_language() throws ParseException {
         Movie movie = getManager().moviesService().summary(TestData.MOVIE_ID, "pt", null);
-        assertNotNull("Result was null.", movie);
-        assertNotNull("Movie Adult was null.", movie.adult);
-        assertEquals("Movie Adult does not match.", false, movie.adult.booleanValue());
-        assertNotNull("Movie backdrop path was null.", movie.backdrop_path);
-        assertNotNull("Movie budget was null.", movie.budget);
-        assertEquals("Movie budget does not match.", 63000000, movie.budget.intValue());
-        assertNotNull("Movie TMDB ID was null.", movie.id);
-        assertEquals("Movie TMDB ID does not match.", TestData.MOVIE_ID, movie.id.intValue());
-        assertEquals("Movie IMDB ID does not match.", "tt0137523", movie.imdb_id);
-        assertEquals("Move orignal title does not match.", "Fight Club", movie.original_title);
-        assertNotNull("Movie overview was null.", movie.overview);
-        assertNotNull("Movie poster path was null.", movie.poster_path);
-        assertNotNull("Movie release date was null.", movie.release_date);
-        assertEquals("Movie release date does not match.", JSON_STRING_DATE.parse("1999-10-14"),
-                movie.release_date);
-        assertNotNull("Movie revenue was null.", movie.revenue);
-        assertEquals("Movie revenue does not match.", 100853753, movie.revenue.intValue());
-        assertNotNull("Movie runtime was null.", movie.runtime);
-        assertEquals("Movie runtime does not match.", 139, movie.runtime.intValue());
-        assertNotNull("Movie tagline was null.", movie.tagline);
-        assertEquals("Move title does not match.", "Clube da Luta", movie.title);
-        assertNotNull("Movie vote_average was null.", movie.vote_average);
-        assertNotNull("Movie vote_count was null.", movie.vote_count);
+        assertThat(movie).isNotNull();
+        assertThat(movie.title).isEqualTo("Clube da Luta");
+    }
+
+    private void assertMovie(Movie movie) {
+        assertThat(movie).isNotNull();
+        assertThat(movie.id).isEqualTo(TestData.MOVIE_ID);
+        assertThat(movie.title).isEqualTo(TestData.MOVIE_TITLE);
+        assertThat(movie.overview).isNotEmpty();
+        assertThat(movie.tagline).isNotEmpty();
+        assertThat(movie.adult).isFalse();
+        assertThat(movie.backdrop_path).isNotEmpty();
+        assertThat(movie.budget).isEqualTo(63000000);
+        assertThat(movie.imdb_id).isEqualTo(TestData.MOVIE_IMDB);
+        assertThat(movie.poster_path).isNotEmpty();
+        assertThat(movie.release_date).isEqualTo("1999-10-14");
+        assertThat(movie.revenue).isEqualTo(100853753);
+        assertThat(movie.runtime).isEqualTo(139);
+        assertThat(movie.vote_average).isPositive();
+        assertThat(movie.vote_count).isPositive();
     }
 
     @Test
@@ -113,7 +85,7 @@ public class MoviesServiceTest extends BaseTestCase {
 
         assertNotNull(movie.releases);
     }
-    
+
     @Test
     public void test_summary_append_similar() {
         Movie movie = getManager().moviesService().summary(TestData.MOVIE_ID,
@@ -139,7 +111,7 @@ public class MoviesServiceTest extends BaseTestCase {
         assertNotNull(movie.videos);
         assertNotNull(movie.similar);
     }
-    
+
     @Test
     public void test_alternative_titles() {
         MovieAlternativeTitles titles = getManager().moviesService().alternativeTitles(TestData.MOVIE_ID, null);
@@ -149,7 +121,7 @@ public class MoviesServiceTest extends BaseTestCase {
         assertThat(titles.titles.get(0).iso_3166_1).isEqualTo("PL");
         assertThat(titles.titles.get(0).title).isEqualTo("Podziemny krąg");
     }
-    
+
     @Test
     public void test_credits() {
         Credits credits = getManager().moviesService().credits(TestData.MOVIE_ID);
@@ -160,7 +132,7 @@ public class MoviesServiceTest extends BaseTestCase {
         assertThat(credits.cast.get(0).name).isEqualTo("Edward Norton");
         assertThat(credits.crew).isNotEmpty();
     }
-    
+
     @Test
     public void test_images() {
         Images images = getManager().moviesService().images(TestData.MOVIE_ID, null);
@@ -183,7 +155,7 @@ public class MoviesServiceTest extends BaseTestCase {
         assertThat(images.posters.get(0).vote_average).isPositive();
         assertThat(images.posters.get(0).vote_count).isPositive();
     }
-    
+
     @Test
     public void test_keywords() {
         MovieKeywords keywords = getManager().moviesService().keywords(TestData.MOVIE_ID);
@@ -192,7 +164,7 @@ public class MoviesServiceTest extends BaseTestCase {
         assertThat(keywords.keywords.get(0).id).isEqualTo(825);
         assertThat(keywords.keywords.get(0).name).isEqualTo("support group");
     }
-    
+
     @Test
     public void test_releases() {
         Releases releases = getManager().moviesService().releases(TestData.MOVIE_ID);
@@ -202,7 +174,7 @@ public class MoviesServiceTest extends BaseTestCase {
         assertThat(releases.countries.get(0).certification).isEqualTo("R");
         assertThat(releases.countries.get(0).release_date).isEqualTo("1999-10-14");
     }
-    
+
     @Test
     public void test_videos() {
         Videos videos = getManager().moviesService().videos(TestData.MOVIE_ID);
@@ -216,7 +188,7 @@ public class MoviesServiceTest extends BaseTestCase {
         assertThat(videos.results.get(0).size).isNotNull();
         assertThat(videos.results.get(0).type).isEqualTo("Trailer");
     }
-    
+
     @Test
     public void test_similar() {
         MovieResultsPage results = getManager().moviesService().similar(TestData.MOVIE_ID, 3, null);
@@ -236,7 +208,7 @@ public class MoviesServiceTest extends BaseTestCase {
         assertThat(results.results.get(0).vote_average).isNotNull().isPositive();
         assertThat(results.results.get(0).vote_count).isNotNull().isPositive();
     }
-    
+
     @Test
     public void test_reviews() {
         ReviewResultsPage results = getManager().moviesService().reviews(49026, 1, null);
@@ -251,7 +223,7 @@ public class MoviesServiceTest extends BaseTestCase {
         assertThat(results.results.get(0).content).isNotNull();
         assertThat(results.results.get(0).url).isNotNull();
     }
-    
+
     @Test
     public void test_lists() {
         ListResultsPage results = getManager().moviesService().lists(49026, 1, null);
@@ -269,7 +241,7 @@ public class MoviesServiceTest extends BaseTestCase {
         assertThat(results.results.get(0).name).isNotNull();
         assertThat(results.results.get(0).poster_path).isNotNull();
     }
-    
+
     @Test
     public void test_latest() {
         Movie movie = getManager().moviesService().latest();
@@ -278,7 +250,7 @@ public class MoviesServiceTest extends BaseTestCase {
         assertThat(movie.id).isPositive();
         assertThat(movie.title).isNotEmpty();
     }
-    
+
     @Test
     public void test_upcoming() {
         MovieResultsPage page = getManager().moviesService().upcoming(null, null);
@@ -306,5 +278,5 @@ public class MoviesServiceTest extends BaseTestCase {
         assertThat(page).isNotNull();
         assertThat(page.results).isNotEmpty();
     }
-    
+
 }

--- a/src/test/java/com/uwetrottmann/tmdb/services/MoviesServiceTest.java
+++ b/src/test/java/com/uwetrottmann/tmdb/services/MoviesServiceTest.java
@@ -177,7 +177,7 @@ public class MoviesServiceTest extends BaseTestCase {
 
     @Test
     public void test_videos() {
-        Videos videos = getManager().moviesService().videos(TestData.MOVIE_ID);
+        Videos videos = getManager().moviesService().videos(TestData.MOVIE_ID, null);
         assertThat(videos).isNotNull();
         assertThat(videos.id).isEqualTo(TestData.MOVIE_ID);
         assertThat(videos.results.get(0).id).isNotNull();

--- a/src/test/java/com/uwetrottmann/tmdb/services/MoviesServiceTest.java
+++ b/src/test/java/com/uwetrottmann/tmdb/services/MoviesServiceTest.java
@@ -272,8 +272,11 @@ public class MoviesServiceTest extends BaseTestCase {
     
     @Test
     public void test_latest() {
-        Movie page = getManager().moviesService().latest();
-        assertThat(page).isNotNull();
+        Movie movie = getManager().moviesService().latest();
+        // Latest movie might not have a complete TMDb entry, but should at least some basic properties.
+        assertThat(movie).isNotNull();
+        assertThat(movie.id).isPositive();
+        assertThat(movie.title).isNotEmpty();
     }
     
     @Test

--- a/src/test/java/com/uwetrottmann/tmdb/services/PeopleServiceTest.java
+++ b/src/test/java/com/uwetrottmann/tmdb/services/PeopleServiceTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-public class PersonServiceTest extends BaseTestCase {
+public class PeopleServiceTest extends BaseTestCase {
 
     private static final SimpleDateFormat JSON_STRING_DATE = new SimpleDateFormat("yyy-MM-dd");
 
@@ -98,7 +98,7 @@ public class PersonServiceTest extends BaseTestCase {
     
     @Test
     public void test_popular() {
-        PersonResultsPage popular = getManager().personService().popular();
+        PersonResultsPage popular = getManager().personService().popular(null);
         
         assertThat(popular.results.get(0).id).isNotNull();
         assertThat(popular.results.get(0).name).isNotNull();

--- a/src/test/java/com/uwetrottmann/tmdb/services/PeopleServiceTest.java
+++ b/src/test/java/com/uwetrottmann/tmdb/services/PeopleServiceTest.java
@@ -124,7 +124,8 @@ public class PeopleServiceTest extends BaseTestCase {
     @Test
     public void test_latest() throws ParseException {
         Person person = getManager().personService().latest();
-        assertNotNull("Result was null.", person);
+        // Latest person might not have a complete TMDb entry, but at should least some basic properties.
+        assertThat(person).isNotNull();
         assertThat(person.name).isNotNull();
         assertThat(person.id).isNotNull();
     }

--- a/src/test/java/com/uwetrottmann/tmdb/services/TvServiceTest.java
+++ b/src/test/java/com/uwetrottmann/tmdb/services/TvServiceTest.java
@@ -125,7 +125,10 @@ public class TvServiceTest extends BaseTestCase {
     @Test
     public void test_latest() {
         TvShowComplete show = getManager().tvService().latest();
-        assertTvShow(show);
+        // Latest show might not have a complete TMDb entry, but at should least some basic properties.
+        assertThat(show).isNotNull();
+        assertThat(show.id).isPositive();
+        assertThat(show.name).isNotEmpty();
     }
     
     @Test


### PR DESCRIPTION
 * Support more services (Discover, TV seasons and episodes) and methods, thanks to @migueljteixeira!
 * Drop method variants (e.g. movie summary call with just a TMDb id). Use the full parameter variant and supply `null`
   for non-required query parameters.
 * Drop any async variants for methods. They only encourage bad programming (e.g. not using proper background threads).
 * Renamed `PersonService` to `PeopleService` to be consistent with docs.
 * Switch to JUnit 4 for testing.
 * Update `retrofit` to 1.9.0, which allows to drop the `okhttp-urlconnection` dependency.
 * Update `okhttp` suggested dependency to 2.2.0.
 * Require Java 1.7.