### PR TITLE
New movie endpoint: release_dates

### DIFF
--- a/src/main/java/com/uwetrottmann/tmdb/entities/Movie.java
+++ b/src/main/java/com/uwetrottmann/tmdb/entities/Movie.java
@@ -49,6 +49,7 @@ public class Movie {
     // Following are used with append_to_response
     public Videos videos;
     public Releases releases;
+    public ReleaseDatesResult release_dates;
     public Credits credits;
     public MovieResultsPage similar;
 }

--- a/src/main/java/com/uwetrottmann/tmdb/entities/ReleaseDate.java
+++ b/src/main/java/com/uwetrottmann/tmdb/entities/ReleaseDate.java
@@ -2,9 +2,6 @@ package com.uwetrottmann.tmdb.entities;
 
 import java.util.Date;
 
-/**
- * Created by Urizev on 3/3/16.
- */
 public class ReleaseDate {
     public static int TYPE_PREMIERE           = 1;
     public static int TYPE_THEATRICAL_LIMITED = 2;

--- a/src/main/java/com/uwetrottmann/tmdb/entities/ReleaseDate.java
+++ b/src/main/java/com/uwetrottmann/tmdb/entities/ReleaseDate.java
@@ -1,0 +1,21 @@
+package com.uwetrottmann.tmdb.entities;
+
+import java.util.Date;
+
+/**
+ * Created by Urizev on 3/3/16.
+ */
+public class ReleaseDate {
+    public static int TYPE_PREMIERE           = 1;
+    public static int TYPE_THEATRICAL_LIMITED = 2;
+    public static int TYPE_THEATRICAL         = 3;
+    public static int TYPE_DIGITAL            = 4;
+    public static int TYPE_PHYSICAL           = 5;
+    public static int TYPE_TV                 = 6;
+
+    public String certification;
+    public String iso_639_1;
+    public String note;
+    public Date release_date;
+    public int type;
+}

--- a/src/main/java/com/uwetrottmann/tmdb/entities/ReleaseDatesResult.java
+++ b/src/main/java/com/uwetrottmann/tmdb/entities/ReleaseDatesResult.java
@@ -2,9 +2,6 @@ package com.uwetrottmann.tmdb.entities;
 
 import java.util.List;
 
-/**
- * Created by Urizev on 3/3/16.
- */
 public class ReleaseDatesResult {
     public String iso_3166_1;
     public List<ReleaseDate> release_dates;

--- a/src/main/java/com/uwetrottmann/tmdb/entities/ReleaseDatesResult.java
+++ b/src/main/java/com/uwetrottmann/tmdb/entities/ReleaseDatesResult.java
@@ -1,0 +1,11 @@
+package com.uwetrottmann.tmdb.entities;
+
+import java.util.List;
+
+/**
+ * Created by Urizev on 3/3/16.
+ */
+public class ReleaseDatesResult {
+    public String iso_3166_1;
+    public List<ReleaseDate> release_dates;
+}

--- a/src/main/java/com/uwetrottmann/tmdb/entities/ReleaseDatesResults.java
+++ b/src/main/java/com/uwetrottmann/tmdb/entities/ReleaseDatesResults.java
@@ -1,0 +1,11 @@
+package com.uwetrottmann.tmdb.entities;
+
+import java.util.List;
+
+/**
+ * Created by Urizev on 3/3/16.
+ */
+public class ReleaseDatesResults {
+    public int id;
+    public List<ReleaseDatesResult> results;
+}

--- a/src/main/java/com/uwetrottmann/tmdb/entities/ReleaseDatesResults.java
+++ b/src/main/java/com/uwetrottmann/tmdb/entities/ReleaseDatesResults.java
@@ -2,9 +2,6 @@ package com.uwetrottmann.tmdb.entities;
 
 import java.util.List;
 
-/**
- * Created by Urizev on 3/3/16.
- */
 public class ReleaseDatesResults {
     public int id;
     public List<ReleaseDatesResult> results;

--- a/src/main/java/com/uwetrottmann/tmdb/enumerations/AppendToResponseItem.java
+++ b/src/main/java/com/uwetrottmann/tmdb/enumerations/AppendToResponseItem.java
@@ -22,6 +22,7 @@ public enum AppendToResponseItem {
 
     VIDEOS("videos"),
     RELEASES("releases"),
+    RELEASE_DATES("release_dates"),
     CREDITS("credits"),
     SIMILAR("similar"),
     IMAGES("images"),

--- a/src/main/java/com/uwetrottmann/tmdb/services/MoviesService.java
+++ b/src/main/java/com/uwetrottmann/tmdb/services/MoviesService.java
@@ -17,18 +17,7 @@
 
 package com.uwetrottmann.tmdb.services;
 
-import com.uwetrottmann.tmdb.entities.AppendToResponse;
-import com.uwetrottmann.tmdb.entities.Credits;
-import com.uwetrottmann.tmdb.entities.Images;
-import com.uwetrottmann.tmdb.entities.ListResultsPage;
-import com.uwetrottmann.tmdb.entities.Movie;
-import com.uwetrottmann.tmdb.entities.MovieAlternativeTitles;
-import com.uwetrottmann.tmdb.entities.MovieKeywords;
-import com.uwetrottmann.tmdb.entities.MovieResultsPage;
-import com.uwetrottmann.tmdb.entities.Releases;
-import com.uwetrottmann.tmdb.entities.ReviewResultsPage;
-import com.uwetrottmann.tmdb.entities.Videos;
-import com.uwetrottmann.tmdb.entities.Translations;
+import com.uwetrottmann.tmdb.entities.*;
 import retrofit.http.GET;
 import retrofit.http.Path;
 import retrofit.http.Query;
@@ -100,6 +89,19 @@ public interface MoviesService {
      */
     @GET("/movie/{id}/releases")
     Releases releases(
+            @Path("id") int tmdbId
+    );
+
+    /**
+     * Get the release dates, certifications and related information by country for a specific movie id.
+     *
+     * The results are keyed by iso_3166_1 code and contain a type value which on our system, maps to:
+     * TYPE_PREMIERE, TYPE_THEATRICAL_LIMITED, TYPE_THEATRICAL, TYPE_DIGITAL, TYPE_PHYSICAL, TYPE_TV
+     *
+     * @param tmdbId TMDb id.
+     */
+    @GET("/movie/{id}/release_dates")
+    ReleaseDatesResults releaseDates(
             @Path("id") int tmdbId
     );
 

--- a/src/test/java/com/uwetrottmann/tmdb/services/MoviesServiceTest.java
+++ b/src/test/java/com/uwetrottmann/tmdb/services/MoviesServiceTest.java
@@ -194,20 +194,23 @@ public class MoviesServiceTest extends BaseTestCase {
         assertThat(results.id).isEqualTo(TestData.MOVIE_ID);
         assertThat(results.results).isNotNull();
         assertThat(results.results.isEmpty()).isFalse();
+
         ReleaseDatesResult usResult = null;
         for (ReleaseDatesResult result : results.results) {
             assertThat(result.iso_3166_1).isNotNull();
             if (result.iso_3166_1.equals("US")) {
                 usResult = result;
-                break;
             }
         }
+
         assertThat(usResult).isNotNull();
         assertThat(usResult.release_dates).isNotNull();
         assertThat(usResult.release_dates.isEmpty()).isFalse();
         assertThat(usResult.release_dates.get(0).iso_639_1).isNotNull();
         assertThat(usResult.release_dates.get(0).certification).isEqualTo("R");
         assertThat(usResult.release_dates.get(0).release_date).isEqualTo("1999-10-14T00:00:00.000Z");
+        assertThat(usResult.release_dates.get(0).note).isNotNull();
+        assertThat(usResult.release_dates.get(0).type).isBetween(1, 6);
     }
 
     @Test

--- a/src/test/java/com/uwetrottmann/tmdb/services/MoviesServiceTest.java
+++ b/src/test/java/com/uwetrottmann/tmdb/services/MoviesServiceTest.java
@@ -87,6 +87,16 @@ public class MoviesServiceTest extends BaseTestCase {
     }
 
     @Test
+    public void test_summary_append_release_dates() {
+        Movie movie = getManager().moviesService().summary(TestData.MOVIE_ID,
+                null,
+                new AppendToResponse(
+                        AppendToResponseItem.RELEASE_DATES));
+
+        assertNotNull(movie.release_dates);
+    }
+
+    @Test
     public void test_summary_append_similar() {
         Movie movie = getManager().moviesService().summary(TestData.MOVIE_ID,
                 null,
@@ -102,11 +112,13 @@ public class MoviesServiceTest extends BaseTestCase {
                 null,
                 new AppendToResponse(
                         AppendToResponseItem.RELEASES,
+                        AppendToResponseItem.RELEASE_DATES,
                         AppendToResponseItem.CREDITS,
                         AppendToResponseItem.VIDEOS,
                         AppendToResponseItem.SIMILAR));
 
         assertNotNull(movie.releases);
+        assertNotNull(movie.release_dates);
         assertNotNull(movie.credits);
         assertNotNull(movie.videos);
         assertNotNull(movie.similar);

--- a/src/test/java/com/uwetrottmann/tmdb/services/MoviesServiceTest.java
+++ b/src/test/java/com/uwetrottmann/tmdb/services/MoviesServiceTest.java
@@ -4,18 +4,7 @@ package com.uwetrottmann.tmdb.services;
 import com.uwetrottmann.tmdb.BaseTestCase;
 import com.uwetrottmann.tmdb.TestData;
 
-import com.uwetrottmann.tmdb.entities.AppendToResponse;
-import com.uwetrottmann.tmdb.entities.Credits;
-import com.uwetrottmann.tmdb.entities.Images;
-import com.uwetrottmann.tmdb.entities.ListResultsPage;
-import com.uwetrottmann.tmdb.entities.Movie;
-import com.uwetrottmann.tmdb.entities.MovieAlternativeTitles;
-import com.uwetrottmann.tmdb.entities.MovieKeywords;
-import com.uwetrottmann.tmdb.entities.MovieResultsPage;
-import com.uwetrottmann.tmdb.entities.Releases;
-import com.uwetrottmann.tmdb.entities.ReviewResultsPage;
-import com.uwetrottmann.tmdb.entities.Videos;
-import com.uwetrottmann.tmdb.entities.Translations;
+import com.uwetrottmann.tmdb.entities.*;
 import com.uwetrottmann.tmdb.enumerations.AppendToResponseItem;
 import org.junit.Test;
 
@@ -184,6 +173,29 @@ public class MoviesServiceTest extends BaseTestCase {
         assertThat(releases.countries.get(0).iso_3166_1).isEqualTo("US");
         assertThat(releases.countries.get(0).certification).isEqualTo("R");
         assertThat(releases.countries.get(0).release_date).isEqualTo("1999-10-14");
+    }
+
+    @Test
+    public void test_release_dates() {
+        ReleaseDatesResults results = getManager().moviesService().releaseDates(TestData.MOVIE_ID);
+        assertThat(results).isNotNull();
+        assertThat(results.id).isEqualTo(TestData.MOVIE_ID);
+        assertThat(results.results).isNotNull();
+        assertThat(results.results.isEmpty()).isFalse();
+        ReleaseDatesResult usResult = null;
+        for (ReleaseDatesResult result : results.results) {
+            assertThat(result.iso_3166_1).isNotNull();
+            if (result.iso_3166_1.equals("US")) {
+                usResult = result;
+                break;
+            }
+        }
+        assertThat(usResult).isNotNull();
+        assertThat(usResult.release_dates).isNotNull();
+        assertThat(usResult.release_dates.isEmpty()).isFalse();
+        assertThat(usResult.release_dates.get(0).iso_639_1).isNotNull();
+        assertThat(usResult.release_dates.get(0).certification).isEqualTo("R");
+        assertThat(usResult.release_dates.get(0).release_date).isEqualTo("1999-10-14T00:00:00.000Z");
     }
 
     @Test


### PR DESCRIPTION
Adds /movie/{id}/release_dates endpoint and new release_dates as append_to_response item.
Also, adds a test for new endpoint and a test the new append_to_response_item

The addition is motivated due to current /movie/{id}/releases endpoint is being deprecated as author says here:

   https://plus.google.com/+TravisBellTMDb/posts/4uNG5uSwtfe?hl=en

MovieService has a new method releaseDates() which returns a new structure consisting of three new classes: ReleaseDatesResults, ReleaseDatesResult and ReleaseDate (old Releases and CountryRelease classes cannot be used here).

I wanted to pull against dev as you say in header but I didn't find such branch (maybe for my reduced experience using Github).