### PR TITLE
Bug fix getting movie details with release_dates appended

### DIFF
--- a/src/main/java/com/uwetrottmann/tmdb/entities/Movie.java
+++ b/src/main/java/com/uwetrottmann/tmdb/entities/Movie.java
@@ -49,7 +49,7 @@ public class Movie {
     // Following are used with append_to_response
     public Videos videos;
     public Releases releases;
-    public ReleaseDatesResult release_dates;
+    public ReleaseDatesResults release_dates;
     public Credits credits;
     public MovieResultsPage similar;
 }

--- a/src/test/java/com/uwetrottmann/tmdb/services/MoviesServiceTest.java
+++ b/src/test/java/com/uwetrottmann/tmdb/services/MoviesServiceTest.java
@@ -131,6 +131,8 @@ public class MoviesServiceTest extends BaseTestCase {
 
         assertNotNull(movie.releases);
         assertNotNull(movie.release_dates);
+        assertNotNull(movie.release_dates.results);
+        assertThat(movie.release_dates.results).isNotEmpty();
         assertNotNull(movie.credits);
         assertNotNull(movie.videos);
         assertNotNull(movie.similar);


### PR DESCRIPTION
In my last pull request, I used the wrong ReleaseDatesResult for Movie.release_dates field instead of ReleaseDatesResult**s**