### PR TITLE
Add support for TV Show Content ratings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,12 +48,12 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-            <version>2.0.2</version>
+            <version>2.1.0</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-gson</artifactId>
-            <version>2.0.2</version>
+            <version>2.1.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/src/main/java/com/uwetrottmann/tmdb2/entities/ContentRating.java
+++ b/src/main/java/com/uwetrottmann/tmdb2/entities/ContentRating.java
@@ -1,0 +1,8 @@
+package com.uwetrottmann.tmdb2.entities;
+
+import java.util.List;
+
+public class ContentRating {
+    public String iso_3166_1;
+    public String rating;
+}

--- a/src/main/java/com/uwetrottmann/tmdb2/entities/TvContentRatings.java
+++ b/src/main/java/com/uwetrottmann/tmdb2/entities/TvContentRatings.java
@@ -1,0 +1,8 @@
+package com.uwetrottmann.tmdb2.entities;
+
+import java.util.List;
+
+public class TvContentRatings {
+	public List<ContentRating> results;
+	public Integer id;
+}

--- a/src/main/java/com/uwetrottmann/tmdb2/entities/TvShowComplete.java
+++ b/src/main/java/com/uwetrottmann/tmdb2/entities/TvShowComplete.java
@@ -41,4 +41,5 @@ public class TvShowComplete extends TvShow {
     public Images images;
     public Credits credits;
     public ExternalIds external_ids;
+    public TvContentRatings content_ratings;
 }

--- a/src/main/java/com/uwetrottmann/tmdb2/enumerations/AppendToResponseItem.java
+++ b/src/main/java/com/uwetrottmann/tmdb2/enumerations/AppendToResponseItem.java
@@ -25,7 +25,8 @@ public enum AppendToResponseItem {
     CREDITS("credits"),
     SIMILAR("similar"),
     IMAGES("images"),
-    EXTERNAL_IDS("external_ids");
+    EXTERNAL_IDS("external_ids"),
+    CONTENT_RATINGS("content_ratings");
 
     private final String value;
 

--- a/src/main/java/com/uwetrottmann/tmdb2/services/TvService.java
+++ b/src/main/java/com/uwetrottmann/tmdb2/services/TvService.java
@@ -1,6 +1,7 @@
 package com.uwetrottmann.tmdb2.services;
 
 import com.uwetrottmann.tmdb2.entities.AppendToResponse;
+import com.uwetrottmann.tmdb2.entities.TvContentRatings;
 import com.uwetrottmann.tmdb2.entities.Credits;
 import com.uwetrottmann.tmdb2.entities.ExternalIds;
 import com.uwetrottmann.tmdb2.entities.Images;
@@ -51,6 +52,16 @@ public interface TvService {
     Call<Credits> credits(
             @Path("id") int tmdbId,
             @Query("language") String language
+    );
+
+    /**
+     * Get the content ratings for a specific TV show.
+     *
+     * @param tmbdId A themoviedb id
+     */
+    @GET("tv/{id}/content_ratings")
+    Call<TvContentRatings> content_ratings(
+            @Path("id") int tmbdId
     );
 
     /**

--- a/src/test/java/com/uwetrottmann/tmdb2/services/TvServiceTest.java
+++ b/src/test/java/com/uwetrottmann/tmdb2/services/TvServiceTest.java
@@ -143,7 +143,7 @@ public class TvServiceTest extends BaseTestCase {
         assertThat(videos.results.get(0).name).isNotNull();
         assertThat(videos.results.get(0).site).isEqualTo("YouTube");
         assertThat(videos.results.get(0).size).isNotNull();
-        assertThat(videos.results.get(0).type).isEqualTo("Opening Credits");
+        assertThat(videos.results.get(0).type).isEqualTo("Trailer");
     }
 
     @Test

--- a/src/test/java/com/uwetrottmann/tmdb2/services/TvServiceTest.java
+++ b/src/test/java/com/uwetrottmann/tmdb2/services/TvServiceTest.java
@@ -8,6 +8,7 @@ import com.uwetrottmann.tmdb2.entities.ExternalIds;
 import com.uwetrottmann.tmdb2.entities.Images;
 import com.uwetrottmann.tmdb2.entities.Person;
 import com.uwetrottmann.tmdb2.entities.TvAlternativeTitles;
+import com.uwetrottmann.tmdb2.entities.TvContentRatings;
 import com.uwetrottmann.tmdb2.entities.TvKeywords;
 import com.uwetrottmann.tmdb2.entities.TvResultsPage;
 import com.uwetrottmann.tmdb2.entities.TvSeason;
@@ -35,7 +36,7 @@ public class TvServiceTest extends BaseTestCase {
         Call<TvShowComplete> call = getManager().tvService().tv(
                 TestData.TVSHOW_ID, null,
                 new AppendToResponse(AppendToResponseItem.CREDITS, AppendToResponseItem.EXTERNAL_IDS,
-                        AppendToResponseItem.IMAGES)
+                        AppendToResponseItem.IMAGES, AppendToResponseItem.CONTENT_RATINGS)
         );
         TvShowComplete show = call.execute().body();
         assertTvShow(show);
@@ -57,6 +58,23 @@ public class TvServiceTest extends BaseTestCase {
         assertThat(show.external_ids.tvdb_id).isNotNull();
         assertThat(show.external_ids.imdb_id).isNotNull();
         assertThat(show.external_ids.tvrage_id).isNotNull();
+
+        // content ratings
+        assertThat(show.content_ratings).isNotNull();
+        assertThat(show.content_ratings.results).isNotEmpty();
+        assertThat(show.content_ratings.results.get(0).iso_3166_1).isNotNull();
+        assertThat(show.content_ratings.results.get(0).rating).isNotNull();
+    }
+
+    @Test
+    public void test_content_ratings() throws IOException {
+        Call<TvContentRatings> call = getManager().tvService().content_ratings(TestData.TVSHOW_ID);
+        TvContentRatings ratings = call.execute().body();
+        assertThat(ratings).isNotNull();
+        assertThat(ratings.id).isEqualTo(TestData.TVSHOW_ID);
+        assertThat(ratings.results).isNotEmpty();
+        assertThat(ratings.results.get(0).iso_3166_1).isNotNull();
+        assertThat(ratings.results.get(0).rating).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
Hello,

I've created this pull request to add support for getting content ratings for TV shows, ultimately so I can add support for scraping them in tinyMediaManager.

One note about the update to 2.1.0 of retrofit, I did this because I was getting a conflict in maven that was stopping me from running anything:
 * retrofit 2.0.2 uses okhttp3 3.2.0 
 * tmdb-java requires 3.3.0

maven was resolving the conflict using 3.2.0 (causing all tests to fail to run). I'm very new to using maven so if there's something I missed here I'd welcome a nudge in the right direction.