### PR TITLE
Fixed the typos or mistake in class name in the documentation .

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,5 +53,5 @@ See full [list of contributors](https://github.com/UweTrottmann/tmdb-java/graphs
 Except where noted otherwise, released into the [public domain](UNLICENSE).
 Do not just copy, make it better.
 
-
  [1]: https://square.github.io/retrofit/
+ 

--- a/README.md
+++ b/README.md
@@ -53,5 +53,5 @@ See full [list of contributors](https://github.com/UweTrottmann/tmdb-java/graphs
 Except where noted otherwise, released into the [public domain](UNLICENSE).
 Do not just copy, make it better.
 
+
  [1]: https://square.github.io/retrofit/
- 


### PR DESCRIPTION
The documentation in the ReadMe says the service name for the class is "MovieService" but the library has the class name as "MoviesService" , you have missed an "s" in the classname in the documentation .