### PR TITLE
TMDB allows character data to remain undefined in cast. In such we ca…

### DIFF
--- a/src/main/java/com/uwetrottmann/tmdb2/TmdbHelper.java
+++ b/src/main/java/com/uwetrottmann/tmdb2/TmdbHelper.java
@@ -148,8 +148,12 @@ public class TmdbHelper {
                                                 JsonDeserializationContext jsonDeserializationContext) throws JsonParseException {
                 PersonCastCredit personCastCredit = new PersonCastCredit();
                 personCastCredit.media = jsonDeserializationContext.deserialize(jsonElement, Media.class);
-                personCastCredit.character = jsonElement.getAsJsonObject().get("character").getAsString();
-                personCastCredit.credit_id = jsonElement.getAsJsonObject().get("credit_id").getAsString();
+                if(jsonElement.getAsJsonObject().get("character") != null) {
+                    personCastCredit.character = jsonElement.getAsJsonObject().get("character").getAsString();
+                }
+                if(jsonElement.getAsJsonObject().get("credit_id") != null) {
+                    personCastCredit.credit_id = jsonElement.getAsJsonObject().get("credit_id").getAsString();
+                }
                 switch (personCastCredit.media.media_type) {
                     case TV:
                         personCastCredit.episode_count = jsonElement.getAsJsonObject().get("episode_count").getAsInt();


### PR DESCRIPTION
…nnot rely that the character is present when fetching the data. This, somewhat inelegant, change solves this issue. Example IDs of people effected (that work after this commit): 34842, 41988, 154154, 107098, 4776, 16940, 53568, 5916.