### PR TITLE
Translation object has different names for movies/tvshow

### DIFF
--- a/src/main/java/com/uwetrottmann/tmdb2/entities/Translations.java
+++ b/src/main/java/com/uwetrottmann/tmdb2/entities/Translations.java
@@ -14,7 +14,14 @@ public class Translations {
 
         public static class Data {
 
+            /**
+             * Title for movies
+             */
             public String title;
+            /**
+             * Title for tvshows/episodes
+             */
+            public String name;
             public String overview;
             public String homepage;
         }


### PR DESCRIPTION
follow-up to 1762d8bca0a3f7f5cd63e16fbac146cb020ca78d which only has been tested with movies :|  
Else i would have seen earlier, that TMDB always uses different tags between movies and shows/episodes.  
Movies always have a 'title', whilst shows & episodes always have 'names'.

This is a short compromise, to specify them both.  
Only one gets filled, though, which needs to be checked by user.  

We also could bring this a level higher and create dedicated Movie/TvShow/EpisodeTranslation objects, where we only specify the right one. But still unsure, if it's worth the change...