### PR TITLE
Updated Movie Entity revenue and budget field from int to long. & Test Fixes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,12 +47,12 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-            <version>2.5.0</version>
+            <version>2.6.1</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-gson</artifactId>
-            <version>2.5.0</version>
+            <version>2.6.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>

--- a/src/main/java/com/uwetrottmann/tmdb2/entities/Company.java
+++ b/src/main/java/com/uwetrottmann/tmdb2/entities/Company.java
@@ -6,6 +6,7 @@ public class Company extends BaseCompany {
     public String headquarters;
     public String homepage;
     public Company parent_company;
+    public String origin_country;
 
     public MovieResultsPage movies;
 

--- a/src/main/java/com/uwetrottmann/tmdb2/entities/Movie.java
+++ b/src/main/java/com/uwetrottmann/tmdb2/entities/Movie.java
@@ -7,12 +7,12 @@ import java.util.List;
 public class Movie extends BaseMovie {
 
     public Collection belongs_to_collection;
-    public Integer budget;
+    public Long budget;
     public String homepage;
     public String imdb_id;
     public List<BaseCompany> production_companies;
     public List<Country> production_countries;
-    public Integer revenue;
+    public Long revenue;
     public Integer runtime;
     public List<SpokenLanguage> spoken_languages;
     public Status status;

--- a/src/test/java/com/uwetrottmann/tmdb2/TestData.java
+++ b/src/test/java/com/uwetrottmann/tmdb2/TestData.java
@@ -140,10 +140,10 @@ public class TestData {
         testMovie.status = Status.RELEASED;
         testMovie.tagline = "Some assembly required.";
         testMovie.runtime = 143;
-        testMovie.revenue = 1519557910;
+        testMovie.revenue = 1519557910L;
         testMovie.release_date = JSON_STRING_DATE.parse("2012-04-25");
         testMovie.original_language = "en";
-        testMovie.budget = 220000000;
+        testMovie.budget = 220000000L;
         testMovie.imdb_id = "tt0848228";
         testMovie.overview = "When an unexpected enemy emerges and threatens global safety and security, Nick Fury, director of the international peacekeeping agency known as S.H.I.E.L.D., finds himself in need of a team to pull the world back from the brink of disaster. Spanning the globe, a daring recruitment effort begins!";
         testMovie.homepage = "http://marvel.com/avengers_movie/";

--- a/src/test/java/com/uwetrottmann/tmdb2/TestData.java
+++ b/src/test/java/com/uwetrottmann/tmdb2/TestData.java
@@ -90,6 +90,7 @@ public class TestData {
     private static void initializeTestingIntegrityData() throws ParseException {
         testCompany.id = 5;
         testCompany.name = "Columbia Pictures";
+        testCompany.origin_country = "US";
 
         testPerson.name = "Ben Affleck";
         testPerson.birthday = JSON_STRING_DATE.parse("1972-08-15");

--- a/src/test/java/com/uwetrottmann/tmdb2/assertions/CompanyAssertions.java
+++ b/src/test/java/com/uwetrottmann/tmdb2/assertions/CompanyAssertions.java
@@ -35,7 +35,6 @@ public class CompanyAssertions {
         assertThat(company.headquarters).isNotNull();
         assertThat(company.homepage).isNotNull();
         assertThat(company.origin_country).isNotEmpty();
-        assertThat(company.origin_country).isNotEmpty();
         if (company.parent_company != null)
             assertBaseCompany(company.parent_company, true);
     }

--- a/src/test/java/com/uwetrottmann/tmdb2/assertions/CompanyAssertions.java
+++ b/src/test/java/com/uwetrottmann/tmdb2/assertions/CompanyAssertions.java
@@ -34,7 +34,8 @@ public class CompanyAssertions {
 
         assertThat(company.headquarters).isNotNull();
         assertThat(company.homepage).isNotNull();
-
+        assertThat(company.origin_country).isNotEmpty();
+        assertThat(company.origin_country).isNotEmpty();
         if (company.parent_company != null)
             assertBaseCompany(company.parent_company, true);
     }
@@ -43,6 +44,8 @@ public class CompanyAssertions {
         assertCompany(company);
         assertThat(company.id).isEqualTo(testCompany.id);
         assertThat(company.name).isEqualTo(testCompany.name);
+        assertThat(company.origin_country).isEqualTo(testCompany.origin_country);
         assertThat(company.description).isNotEmpty();
+
     }
 }

--- a/src/test/java/com/uwetrottmann/tmdb2/services/MoviesServiceTest.java
+++ b/src/test/java/com/uwetrottmann/tmdb2/services/MoviesServiceTest.java
@@ -66,7 +66,7 @@ public class MoviesServiceTest extends BaseTestCase {
 
         assertMovie(movie);
 
-        assertThat(movie.title).isEqualTo("Os Vingadores");
+        assertThat(movie.title).isEqualTo("The Avengers - Os Vingadores");
     }
 
 


### PR DESCRIPTION
- Updated Movie Entity revenue and budget field from int to long. & Test Fixes.
- Updated Company entity added origin_country field & Updated Tests
- Upgrade to latest retrofit release to resolve conflicts for projects using newer version of okhttp.