### PR TITLE
Close response before sleep

### DIFF
--- a/src/main/java/com/uwetrottmann/tmdb2/TmdbInterceptor.java
+++ b/src/main/java/com/uwetrottmann/tmdb2/TmdbInterceptor.java
@@ -62,17 +62,18 @@ public class TmdbInterceptor implements Interceptor {
             // re-try if the server indicates we should
             String retryHeader = response.header("Retry-After");
             if (retryHeader != null) {
+                // close body of unsuccessful response
+                response.close();
+
                 try {
                     int retry = Integer.parseInt(retryHeader);
                     Thread.sleep((int) ((retry + 0.5) * 1000));
 
-                    // close body of unsuccessful response
-                    if (response.body() != null) {
-                        response.body().close();
-                    }
                     // is fine because, unlike a network interceptor, an application interceptor can re-try requests
                     return handleIntercept(chain, tmdb);
                 } catch (NumberFormatException | InterruptedException ignored) {
+                    // HTTP Date in Retry-After
+                    // see https://tools.ietf.org/html/rfc7231#section-7.1.3
                 }
             }
         }


### PR DESCRIPTION
If Retry-After is large, it probably makes sense to close before sleeping.  n.b. HAven't observed this, just noticed in the code.