### PR TITLE
Added an alternative DiscoverFilter constructor to allow 'OR' as an operator choice

### DIFF
--- a/src/main/java/com/uwetrottmann/tmdb2/entities/DiscoverFilter.java
+++ b/src/main/java/com/uwetrottmann/tmdb2/entities/DiscoverFilter.java
@@ -22,6 +22,11 @@ public class DiscoverFilter {
         this.items = items;
     }
 
+    public DiscoverFilter(Separator separator, Integer... items) {
+        this.separator = separator;
+        this.items = items;
+    }
+
     public DiscoverFilter(Separator separator, ReleaseType... types) {
         this.separator = separator;
         this.items = new Integer[types.length];

--- a/src/main/java/com/uwetrottmann/tmdb2/entities/DiscoverFilter.java
+++ b/src/main/java/com/uwetrottmann/tmdb2/entities/DiscoverFilter.java
@@ -27,6 +27,9 @@ public class DiscoverFilter {
     }
 
     public DiscoverFilter(Separator separator, ReleaseType... types) {
+        if (types == null){
+            throw new IllegalArgumentException("types must not be null");
+        }
         this.separator = separator;
         this.items = new Integer[types.length];
         for (int i = 0; i < types.length; i++) {
@@ -39,6 +42,9 @@ public class DiscoverFilter {
 
     @Override
     public String toString() {
+        if (separator == null){
+            throw new NullPointerException();
+        }
         if (items == null || items.length == 0) {
             return null;
         }

--- a/src/main/java/com/uwetrottmann/tmdb2/entities/DiscoverFilter.java
+++ b/src/main/java/com/uwetrottmann/tmdb2/entities/DiscoverFilter.java
@@ -18,8 +18,7 @@ public class DiscoverFilter {
     }
 
     public DiscoverFilter(Integer... items) {
-        this.separator = Separator.AND;
-        this.items = items;
+        this(Separator.AND, items);
     }
 
     public DiscoverFilter(Separator separator, Integer... items) {

--- a/src/test/java/com/uwetrottmann/tmdb2/TestData.java
+++ b/src/test/java/com/uwetrottmann/tmdb2/TestData.java
@@ -36,6 +36,7 @@ public class TestData {
 
     public static final Person testPersonCast = new Person();
     public static final Person testPersonCrew = new Person();
+    public static Integer[] testKeywordsId;
 
     public static final Movie testMovie = new Movie();
     public static Date testMovieChangesStartDate;
@@ -107,6 +108,8 @@ public class TestData {
 
         testPersonCrew.id = 7467;
         testPersonCrew.name = "David Fincher";
+
+        testKeywordsId = new Integer[]{34117, 4142, 156866};
 
         testMovieGenreAdventure.name = "Adventure";
         testMovieGenreAdventure.id = 12;

--- a/src/test/java/com/uwetrottmann/tmdb2/services/DiscoverServiceTest.java
+++ b/src/test/java/com/uwetrottmann/tmdb2/services/DiscoverServiceTest.java
@@ -12,6 +12,7 @@ import retrofit2.Call;
 
 import java.io.IOException;
 
+import static com.uwetrottmann.tmdb2.TestData.testKeywordsId;
 import static com.uwetrottmann.tmdb2.TestData.testMovieGenreRomance;
 import static com.uwetrottmann.tmdb2.TestData.testNetwork;
 import static com.uwetrottmann.tmdb2.TestData.testPersonCast;
@@ -32,6 +33,8 @@ public class DiscoverServiceTest extends BaseTestCase {
                 .with_cast(new DiscoverFilter(testPersonCast.id))
                 .with_crew(new DiscoverFilter(testPersonCrew.id))
                 .without_genres(new DiscoverFilter(testMovieGenreRomance.id))
+                .with_keywords(new DiscoverFilter(DiscoverFilter.Separator.OR,
+                        testKeywordsId))
                 .with_release_type(new DiscoverFilter(DiscoverFilter.Separator.OR,
                         ReleaseType.THEATRICAL, ReleaseType.DIGITAL))
                 .build();


### PR DESCRIPTION
* Added `DiscoverFilter(Separator separator, Integer... items)` to complement the existing `DiscoverFilter(Integer... items)` which uses 'AND' as default separator
  * So that 'OR' can be chosen as separator
  * Can be useful for cases when we have a list of wanted genres (keywords/crew/cast) that doesn't have all to be satisfied.
  * Example, Most popular Action, Adventure or Thriller movies:  https://api.themoviedb.org/3/discover/movie?api_key=<<api_key>>&with_genres=28|12|53&sort_by=popularity.desc
  
* Modified `test_discover_movie()` to add a with_keywords condition that covers the newly added constructor
  * The movie now have to contain either keywords {'cult film', 'insomnia', 'based on short story'}
  
* Removed some warnings in DiscoverFilter.java
  * Warnings: Dereference of 'separator' may produce 'NullPointerException'
  * Simply added some asserts
  * Could also have used some 'assertThat' but didn't knew if an additional dependency was worth it.