### PR TITLE
Add wikidata ID to external IDs

### DIFF
--- a/src/main/java/com/uwetrottmann/tmdb2/entities/MovieExternalIds.java
+++ b/src/main/java/com/uwetrottmann/tmdb2/entities/MovieExternalIds.java
@@ -8,5 +8,5 @@ public class MovieExternalIds {
     public String facebook_id;
     public String instagram_id;
     public String twitter_id;
-
+    public String wikidata_id;
 }

--- a/src/main/java/com/uwetrottmann/tmdb2/entities/PersonExternalIds.java
+++ b/src/main/java/com/uwetrottmann/tmdb2/entities/PersonExternalIds.java
@@ -10,5 +10,5 @@ public class PersonExternalIds {
     public Integer tvrage_id;
     public String instagram_id;
     public String twitter_id;
-
+    public String wikidata_id;
 }

--- a/src/main/java/com/uwetrottmann/tmdb2/entities/TvEpisodeExternalIds.java
+++ b/src/main/java/com/uwetrottmann/tmdb2/entities/TvEpisodeExternalIds.java
@@ -8,6 +8,6 @@ public class TvEpisodeExternalIds {
     public String freebase_id;
     public String freebase_mid;
     public Integer tvrage_id;
-
+    public String wikidata_id;
 
 }

--- a/src/main/java/com/uwetrottmann/tmdb2/entities/TvExternalIds.java
+++ b/src/main/java/com/uwetrottmann/tmdb2/entities/TvExternalIds.java
@@ -11,6 +11,5 @@ public class TvExternalIds {
     public String instagram_id;
     public Integer tvrage_id;
     public String twitter_id;
-
-
+    public String wikidata_id;
 }

--- a/src/main/java/com/uwetrottmann/tmdb2/entities/TvSeasonExternalIds.java
+++ b/src/main/java/com/uwetrottmann/tmdb2/entities/TvSeasonExternalIds.java
@@ -8,5 +8,5 @@ public class TvSeasonExternalIds {
     public String freebase_id;
     public String freebase_mid;
     public Integer tvrage_id;
-
+    public String wikidata_id;
 }

--- a/src/main/java/com/uwetrottmann/tmdb2/enumerations/ExternalSource.java
+++ b/src/main/java/com/uwetrottmann/tmdb2/enumerations/ExternalSource.java
@@ -6,7 +6,8 @@ public enum ExternalSource {
     FREEBASE_MID("freebase_mid"),
     FREEBASE_ID("freebase_id"),
     TVRAGE_ID("tvrage_id"),
-    TVDB_ID("tvdb_id");
+    TVDB_ID("tvdb_id"),
+    WIKIDATA_ID("wikidata_id");
 
     private final String value;
 

--- a/src/test/java/com/uwetrottmann/tmdb2/TestData.java
+++ b/src/test/java/com/uwetrottmann/tmdb2/TestData.java
@@ -8,8 +8,10 @@ import com.uwetrottmann.tmdb2.entities.Credit;
 import com.uwetrottmann.tmdb2.entities.CreditMedia;
 import com.uwetrottmann.tmdb2.entities.Genre;
 import com.uwetrottmann.tmdb2.entities.Movie;
+import com.uwetrottmann.tmdb2.entities.MovieExternalIds;
 import com.uwetrottmann.tmdb2.entities.Network;
 import com.uwetrottmann.tmdb2.entities.Person;
+import com.uwetrottmann.tmdb2.entities.PersonExternalIds;
 import com.uwetrottmann.tmdb2.entities.Review;
 import com.uwetrottmann.tmdb2.entities.TvEpisode;
 import com.uwetrottmann.tmdb2.entities.TvEpisodeExternalIds;
@@ -98,6 +100,8 @@ public class TestData {
         testPerson.imdb_id = "nm0000255";
         testPerson.place_of_birth = "Berkeley, California, USA";
         testPerson.adult = false;
+        testPerson.external_ids = new PersonExternalIds();
+        testPerson.external_ids.wikidata_id = "Q483118";
 
         testPersonChangesStartDate = JSON_STRING_DATE.parse("2016-12-16");
         testPersonChangesEndDate = JSON_STRING_DATE.parse("2016-12-28");
@@ -136,6 +140,8 @@ public class TestData {
         testMovie.original_language = "en";
         testMovie.imdb_id = "tt0848228";
         testMovie.adult = false;
+        testMovie.external_ids = new MovieExternalIds();
+        testMovie.external_ids.wikidata_id = "Q182218";
 
         testMovieChangesStartDate = JSON_STRING_DATE.parse("2017-3-24");
         testMovieChangesEndDate = JSON_STRING_DATE.parse("2017-4-2");
@@ -158,6 +164,7 @@ public class TestData {
         testTvShow.external_ids.instagram_id= "thesimpsonsfox";
         testTvShow.external_ids.tvrage_id = 6190;
         testTvShow.external_ids.twitter_id = "thesimpsons";
+        testTvShow.external_ids.wikidata_id = "Q886";
         testTvShow.external_ids.id = testTvShow.id;
         testTvShowChangesStartDate = JSON_STRING_DATE.parse("2017-2-2");
         testTvShowChangesEndDate = JSON_STRING_DATE.parse("2017-2-4");
@@ -176,6 +183,7 @@ public class TestData {
         testTvSeason.external_ids.tvrage_id = 0;
         testTvSeason.external_ids.freebase_id = "/en/the_simpsons_season_1";
         testTvSeason.external_ids.freebase_mid = "/m/0cmqz_";
+        testTvSeason.external_ids.wikidata_id = "Q461483";
         testTvSeasonChangesStartDate = JSON_STRING_DATE.parse("2015-10-10");
         testTvSeasonChangesEndDate = JSON_STRING_DATE.parse("2015-10-24");
 
@@ -190,6 +198,7 @@ public class TestData {
         testTvEpisode.external_ids.freebase_id = "/en/simpsons_roasting_on_an_open_fire";
         testTvEpisode.external_ids.tvdb_id = 55452;
         testTvEpisode.external_ids.tvrage_id = 206468;
+        testTvEpisode.external_ids.wikidata_id = "Q753507";
         testTvEpisodeChangesStartDate = JSON_STRING_DATE.parse("2017-2-2");
         testTvEpisodeChangesEndDate = JSON_STRING_DATE.parse("2017-2-4");
 

--- a/src/test/java/com/uwetrottmann/tmdb2/assertions/MovieAssertions.java
+++ b/src/test/java/com/uwetrottmann/tmdb2/assertions/MovieAssertions.java
@@ -59,6 +59,7 @@ public class MovieAssertions {
         assertMovie(movie);
         assertThat(movie.budget).isGreaterThan(0);
         assertThat(movie.imdb_id).isEqualTo(TestData.testMovie.imdb_id);
+        assertThat(movie.external_ids.wikidata_id).isEqualTo(TestData.testMovie.external_ids.wikidata_id);
         assertThat(movie.production_companies).isNotEmpty();
         assertThat(movie.production_companies.get(0).id).isEqualTo(testProductionCompany.id);
         assertThat(movie.production_companies.get(0).name).isEqualTo(testProductionCompany.name);

--- a/src/test/java/com/uwetrottmann/tmdb2/assertions/PersonAssertions.java
+++ b/src/test/java/com/uwetrottmann/tmdb2/assertions/PersonAssertions.java
@@ -69,6 +69,7 @@ public class PersonAssertions {
 
     public static void assertTestPersonExternalIds(PersonExternalIds ids) {
         assertThat(ids.imdb_id).isEqualTo(testPerson.imdb_id);
+        assertThat(ids.wikidata_id).isEqualTo(testPerson.external_ids.wikidata_id);
     }
 
     public static void assertPersonResultsPage(PersonResultsPage personResultsPage) {

--- a/src/test/java/com/uwetrottmann/tmdb2/assertions/TvAssertions.java
+++ b/src/test/java/com/uwetrottmann/tmdb2/assertions/TvAssertions.java
@@ -215,6 +215,7 @@ public class TvAssertions {
         assertThat(actual.instagram_id).isEqualTo(testTvShow.external_ids.instagram_id);
         assertThat(actual.tvrage_id).isEqualTo(testTvShow.external_ids.tvrage_id);
         assertThat(actual.twitter_id).isEqualTo(testTvShow.external_ids.twitter_id);
+        assertThat(actual.wikidata_id).isEqualTo(testTvShow.external_ids.wikidata_id);
     }
 
     public static void assertTvEpisodeExternalIdsMatch(TvEpisodeExternalIds actual) {
@@ -223,6 +224,7 @@ public class TvAssertions {
         assertThat(actual.freebase_id).isEqualTo(testTvEpisode.external_ids.freebase_id);
         assertThat(actual.freebase_mid).isEqualTo(testTvEpisode.external_ids.freebase_mid);
         assertThat(actual.tvrage_id).isEqualTo(testTvEpisode.external_ids.tvrage_id);
+        assertThat(actual.wikidata_id).isEqualTo(testTvEpisode.external_ids.wikidata_id);
     }
 
     public static void assertTvSeasonExternalIdsMatch(TvSeasonExternalIds actual) {
@@ -230,6 +232,7 @@ public class TvAssertions {
         assertThat(actual.freebase_id).isEqualTo(testTvSeason.external_ids.freebase_id);
         assertThat(actual.freebase_mid).isEqualTo(testTvSeason.external_ids.freebase_mid);
         assertThat(actual.tvrage_id).isEqualTo(testTvSeason.external_ids.tvrage_id);
+        assertThat(actual.wikidata_id).isEqualTo(testTvSeason.external_ids.wikidata_id);
     }
 
 }

--- a/src/test/java/com/uwetrottmann/tmdb2/services/MoviesServiceTest.java
+++ b/src/test/java/com/uwetrottmann/tmdb2/services/MoviesServiceTest.java
@@ -95,7 +95,8 @@ public class MoviesServiceTest extends BaseTestCase {
                         AppendToResponseItem.RECOMMENDATIONS,
                         AppendToResponseItem.REVIEWS,
                         AppendToResponseItem.LISTS,
-                        AppendToResponseItem.KEYWORDS
+                        AppendToResponseItem.KEYWORDS,
+                        AppendToResponseItem.EXTERNAL_IDS
                 ),
                 opts
         );
@@ -179,6 +180,7 @@ public class MoviesServiceTest extends BaseTestCase {
         assertThat(ids.facebook_id).isEqualTo("BladeRunner2049");
         assertThat(ids.instagram_id).isEqualTo("bladerunnermovie");
         assertThat(ids.twitter_id).isEqualTo("bladerunner");
+        assertThat(ids.wikidata_id).isEqualTo("Q21500755");
     }
 
     @Test


### PR DESCRIPTION
Wikidata IDs are now provided by the API as well. Some tests might still fail though as I only just now added the Wikidata ID to some of your test data on TMDB's side. (Blade Runner 2049, Simpsons)