### PR TITLE
Add Episode type attribute

### DIFF
--- a/src/main/java/com/uwetrottmann/tmdb2/TmdbHelper.java
+++ b/src/main/java/com/uwetrottmann/tmdb2/TmdbHelper.java
@@ -15,6 +15,7 @@ import com.uwetrottmann.tmdb2.entities.PersonCastCredit;
 import com.uwetrottmann.tmdb2.entities.PersonCrewCredit;
 import com.uwetrottmann.tmdb2.entities.RatingObject;
 import com.uwetrottmann.tmdb2.entities.Trending;
+import com.uwetrottmann.tmdb2.enumerations.EpisodeType;
 import com.uwetrottmann.tmdb2.enumerations.MediaType;
 import com.uwetrottmann.tmdb2.enumerations.Status;
 import com.uwetrottmann.tmdb2.enumerations.VideoType;
@@ -178,6 +179,16 @@ public class TmdbHelper {
                             break;
                     }
                     return trending;
+                });
+
+        builder.registerTypeAdapter(EpisodeType.class,
+                (JsonDeserializer<EpisodeType>) (jsonElement, type, jsonDeserializationContext) -> {
+                    String value = jsonElement.getAsString();
+                    if (value != null) {
+                        return EpisodeType.fromValue(value);
+                    } else {
+                        return null;
+                    }
                 });
 
         return builder;

--- a/src/main/java/com/uwetrottmann/tmdb2/entities/BaseTvEpisode.java
+++ b/src/main/java/com/uwetrottmann/tmdb2/entities/BaseTvEpisode.java
@@ -1,5 +1,6 @@
 package com.uwetrottmann.tmdb2.entities;
 
+import com.uwetrottmann.tmdb2.enumerations.EpisodeType;
 import java.util.Date;
 
 public class BaseTvEpisode extends BaseTvEpisodeRatingObject {
@@ -16,5 +17,6 @@ public class BaseTvEpisode extends BaseTvEpisodeRatingObject {
 
     public Date air_date;
     public Integer episode_number;
+    public EpisodeType episode_type;
 
 }

--- a/src/main/java/com/uwetrottmann/tmdb2/enumerations/EpisodeType.java
+++ b/src/main/java/com/uwetrottmann/tmdb2/enumerations/EpisodeType.java
@@ -1,0 +1,29 @@
+package com.uwetrottmann.tmdb2.enumerations;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum EpisodeType {
+    STANDARD("standard"),
+    MID_SEASON_FINALE("mid_season"),
+    FINALE("finale");
+
+    private final String value;
+
+    EpisodeType(String value) { this.value = value; }
+
+    private static final Map<String, EpisodeType> STRING_MAPPING = new HashMap<>();
+
+    static {
+        for (EpisodeType via : EpisodeType.values()) {
+            STRING_MAPPING.put(via.toString().toUpperCase(), via);
+        }
+    }
+
+    public static EpisodeType fromValue(String value) {
+        return STRING_MAPPING.get(value.toUpperCase());
+    }
+
+    @Override
+    public String toString() { return value; }
+}

--- a/src/test/java/com/uwetrottmann/tmdb2/TestData.java
+++ b/src/test/java/com/uwetrottmann/tmdb2/TestData.java
@@ -20,6 +20,7 @@ import com.uwetrottmann.tmdb2.entities.TvSeason;
 import com.uwetrottmann.tmdb2.entities.TvSeasonExternalIds;
 import com.uwetrottmann.tmdb2.entities.TvShow;
 import com.uwetrottmann.tmdb2.enumerations.CreditType;
+import com.uwetrottmann.tmdb2.enumerations.EpisodeType;
 import com.uwetrottmann.tmdb2.enumerations.MediaType;
 import com.uwetrottmann.tmdb2.enumerations.Status;
 import java.text.ParseException;
@@ -192,6 +193,7 @@ public class TestData {
         testTvEpisode.season_number = 1;
         testTvEpisode.episode_number = 1;
         testTvEpisode.air_date = JSON_STRING_DATE.parse("1989-12-17");
+        testTvEpisode.episode_type = EpisodeType.STANDARD;
         testTvEpisode.external_ids = new TvEpisodeExternalIds();
         testTvEpisode.external_ids.imdb_id = "tt0348034";
         testTvEpisode.external_ids.freebase_mid = "/m/0129zr";

--- a/src/test/java/com/uwetrottmann/tmdb2/assertions/TvAssertions.java
+++ b/src/test/java/com/uwetrottmann/tmdb2/assertions/TvAssertions.java
@@ -148,6 +148,7 @@ public class TvAssertions {
         assertThat(tvSeason.episodes).isNotEmpty();
         for (TvEpisode tvEpisode : tvSeason.episodes) {
             assertTvEpisode(tvEpisode);
+            assertThat(tvEpisode.episode_type).isNotNull();
         }
     }
 


### PR DESCRIPTION
For a couple of months now, TMDB has been providing episode types (`standard`, `mid_season` and `finale`) when calling for tv season details.
With this PR, I added an episode_type attribute as an Enum to BaseTvEpisode.
Somehow, when calling for details of a single episode, the episode type is not provided which is why in those cases, the corresponding attribute will null.